### PR TITLE
feat(player): 添加歌曲封面和LRC歌词播放支持

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miot",
-  "version": "2026.6.10",
+  "version": "2026.6.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miot",
-      "version": "2026.6.10",
+      "version": "2026.6.16",
       "devDependencies": {
         "@songloft/plugin-builder": "^2.4.3",
         "@songloft/plugin-sdk": "^2.4.3",

--- a/src/player/manager.ts
+++ b/src/player/manager.ts
@@ -220,11 +220,11 @@ export class PlaylistManager {
    * 获取播放状态
    */
   getStatus(): PlayerStatus {
-    let currentSong: { id: number; title: string; artist: string } | undefined;
+    let currentSong: { id: number; title: string; artist: string; cover_url?: string; lyric_url?: string } | undefined;
     let duration = 0;
     if (this.currentIndex >= 0 && this.currentIndex < this.songs.length) {
       const song = this.songs[this.currentIndex];
-      currentSong = { id: song.id, title: song.title, artist: song.artist };
+      currentSong = { id: song.id, title: song.title, artist: song.artist, cover_url: song.cover_url, lyric_url: song.lyric_url };
       duration = song.duration;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -251,7 +251,7 @@ export interface PlayerStatus {
   play_mode: PlayMode;
   playlist_id: number;
   current_index: number;
-  current_song?: { id: number; title: string; artist: string };
+  current_song?: { id: number; title: string; artist: string; cover_url?: string; lyric_url?: string };
   position: number;
   duration: number;
   is_playing: boolean;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -658,6 +658,15 @@
     border-bottom: 1px solid var(--md-outline-variant);
 }
 
+/* 歌曲列表封面 */
+.song-item-cover {
+    width: 48px;
+    height: 48px;
+    border-radius: var(--md-radius-sm);
+    object-fit: cover;
+    flex-shrink: 0;
+}
+
 /* 最后一项不要底部边框 */
 .song-item:last-child {
     border-bottom: none;
@@ -2891,4 +2900,75 @@ html.embed #tab-player {
 html.embed .playlist-selector {
     top: 92px !important;
     left: 0 !important;
+}
+
+/* ============================================ */
+/* Cover & Lyrics Styles                        */
+/* ============================================ */
+
+/* Player bar cover */
+.player-bar-cover-wrap {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    border-radius: var(--md-radius-md);
+    overflow: hidden;
+    cursor: pointer;
+    flex-shrink: 0;
+    margin-right: 12px;
+    position: relative;
+}
+
+.player-bar-cover {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: none;
+}
+
+.player-bar-cover-wrap:has(.player-bar-cover[src]):not(.player-bar-cover[src=""]) .player-bar-cover {
+    display: block;
+}
+
+.player-bar-cover-wrap:hover {
+    background: var(--md-surface-variant);
+}
+
+/* Player bar info - lyric line */
+.player-bar-info {
+    flex: 1;
+    min-width: 0;
+}
+
+.player-bar-lyric {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--md-on-surface);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-height: 20px;
+    line-height: 20px;
+}
+
+.player-bar-meta {
+    display: none;
+}
+
+.player-bar-cover-wrap:has(.player-bar-cover[src]):not(.player-bar-cover[src=""]) ~ .player-bar-info .player-bar-meta {
+    display: none;
+}
+
+/* Embed mode adjustments */
+html.embed .player-bar-cover-wrap {
+    width: 48px;
+    height: 48px;
+    margin-right: 8px;
+}
+
+html.embed .player-bar-cover {
+    width: 100%;
+    height: 100%;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -650,8 +650,13 @@
     <!-- 固定播放控制栏 -->
     <div class="player-bar">
         <div class="player-bar-info">
-            <div class="player-bar-title" id="currentSongTitle">暂无播放</div>
-            <div class="player-bar-artist" id="currentSongArtist">-</div>
+            <!-- 歌词行 -->
+            <div class="player-bar-lyric" id="playerBarLyric">暂无歌词</div>
+            <!-- 歌曲信息（封面隐藏时显示） -->
+            <div class="player-bar-meta" id="playerBarMeta">
+                <div class="player-bar-title" id="currentSongTitle">暂无播放</div>
+                <div class="player-bar-artist" id="currentSongArtist">-</div>
+            </div>
         </div>
         <!-- 播放进度条 -->
         <div class="progress-bar-container">
@@ -937,6 +942,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+
     <script type="module" src="static/js/app.js"></script>
 </body>
 </html>

--- a/static/js/lrc-parser.js
+++ b/static/js/lrc-parser.js
@@ -1,0 +1,87 @@
+/**
+ * LRC 歌词解析器
+ * 解析 LRC 格式歌词为时间轴数组，支持同步高亮显示
+ */
+
+/** @typedef {{ time: number; text: string }} LyricLine */
+
+/**
+ * 解析 LRC 格式歌词
+ * @param {string} lrcText - LRC 格式歌词文本
+ * @returns {LyricLine[]} 解析后的歌词行
+ */
+export function parseLrc(lrcText) {
+    if (!lrcText) return [];
+
+    const lines = lrcText.split('\n');
+    const lyrics = [];
+    const timeRegex = /\[(\d{2}):(\d{2})\.(\d{2,3})\]/g;
+
+    for (const line of lines) {
+        if (!line.trim()) continue;
+
+        timeRegex.lastIndex = 0;
+        const text = line.replace(/\[\d{2}:\d{2}\.\d{2,3}\]/g, '').trim();
+
+        if (!text) continue;
+
+        // 循环提取所有时间标签，为每个时间生成独立歌词条目
+        let match;
+        while ((match = timeRegex.exec(line)) !== null) {
+            const minutes = parseInt(match[1], 10);
+            const seconds = parseInt(match[2], 10);
+            const millis = match[3].length === 3
+                ? parseInt(match[3], 10)
+                : parseInt(match[3] + '0'.repeat(3 - match[3].length), 10);
+            const time = minutes * 60 + seconds + millis / 1000;
+
+            lyrics.push({ time, text });
+        }
+    }
+
+    // 按时间排序
+    lyrics.sort((a, b) => a.time - b.time);
+    return lyrics;
+}
+
+/**
+ * 获取当前播放进度对应的歌词行索引
+ * @param {LyricLine[]} lyrics - 歌词数组
+ * @param {number} position - 当前播放位置（秒）
+ * @returns {number} 当前歌词行索引，-1 表示无匹配
+ */
+export function getCurrentLyricIndex(lyrics, position) {
+    if (!lyrics || lyrics.length === 0 || position < 0) return -1;
+
+    let currentIndex = -1;
+    for (let i = 0; i < lyrics.length; i++) {
+        if (position >= lyrics[i].time) {
+            currentIndex = i;
+        } else {
+            break;
+        }
+    }
+    return currentIndex;
+}
+
+/**
+ * 获取歌词行对应的秒数
+ * @param {LyricLine[]} lyrics - 歌词数组
+ * @param {number} index - 歌词行索引
+ * @returns {number} 秒数
+ */
+export function getLyricTime(lyrics, index) {
+    if (!lyrics || index < 0 || index >= lyrics.length) return 0;
+    return lyrics[index].time;
+}
+
+/**
+ * 获取歌词文本
+ * @param {LyricLine[]} lyrics - 歌词数组
+ * @param {number} index - 歌词行索引
+ * @returns {string} 歌词文本
+ */
+export function getLyricText(lyrics, index) {
+    if (!lyrics || index < 0 || index >= lyrics.length) return '';
+    return lyrics[index].text;
+}

--- a/static/js/playback.js
+++ b/static/js/playback.js
@@ -3,10 +3,11 @@
  * 负责播放/停止/切歌/播放模式/音量控制/设备状态
  */
 
-const { apiGet, apiPost } = SongloftPlugin;
+const { apiGet, apiPost, getAuthToken } = SongloftPlugin;
 import { showSnackbar, showLoading, hideLoading, showResult, getAccountId, getDeviceId } from './utils.js';
 import { getAllAccountDevices, getDeviceInfo, closeDeviceSelectPanel } from './device.js';
 import { loadPlaylistSongs, highlightSongItem } from './playlist.js';
+import { parseLrc, getCurrentLyricIndex } from './lrc-parser.js';
 
 /** 播放进度相关状态 */
 let currentPosition = 0;    // 当前播放位置（秒）
@@ -14,6 +15,11 @@ let currentDuration = 0;    // 歌曲总时长（秒）
 let isCurrentlyPlaying = false; // 当前是否正在播放
 let lastUpdateTime = 0;     // 上次同步时的 performance.now() 时间戳
 let progressRAF = null;     // requestAnimationFrame ID
+
+/** 歌词相关状态 */
+let currentLyrics = [];     // 解析后的歌词数组
+let currentLyricUrl = '';   // 当前歌词 URL
+let lyricFetchTimer = null; // 歌词获取防抖定时器
 
 /**
  * 格式化时间为 m:ss 格式
@@ -236,17 +242,35 @@ export function togglePlayPause() {
 export function updatePlayerUI(status) {
     if (!status) return;
 
-    // 更新当前歌曲名称和歌手
+    // 更新歌词
+    const playerBarLyric = document.getElementById('playerBarLyric');
+    if (status.current_song && status.current_song.lyric_url) {
+        const lyricUrl = status.current_song.lyric_url;
+        if (lyricUrl !== currentLyricUrl) {
+            currentLyricUrl = lyricUrl;
+            fetchLyrics(lyricUrl);
+        }
+    } else {
+        currentLyricUrl = '';
+        currentLyrics = [];
+        if (playerBarLyric) playerBarLyric.textContent = '暂无歌词';
+    }
+
+    // 更新当前歌词行
+    if (currentLyrics.length > 0) {
+        const lyricIdx = getCurrentLyricIndex(currentLyrics, currentPosition);
+        if (lyricIdx >= 0) {
+            if (playerBarLyric) playerBarLyric.textContent = currentLyrics[lyricIdx].text;
+        }
+    }
+
+    // 更新歌曲信息
     const currentSongTitleEl = document.getElementById('currentSongTitle');
     const currentSongArtistEl = document.getElementById('currentSongArtist');
 
     if (status.current_song) {
-        if (currentSongTitleEl) {
-            currentSongTitleEl.textContent = status.current_song.title || '未知歌曲';
-        }
-        if (currentSongArtistEl) {
-            currentSongArtistEl.textContent = status.current_song.artist || '未知艺术家';
-        }
+        if (currentSongTitleEl) currentSongTitleEl.textContent = status.current_song.title || '未知歌曲';
+        if (currentSongArtistEl) currentSongArtistEl.textContent = status.current_song.artist || '未知艺术家';
     } else {
         if (currentSongTitleEl) currentSongTitleEl.textContent = '暂无播放';
         if (currentSongArtistEl) currentSongArtistEl.textContent = '-';
@@ -752,4 +776,72 @@ export function closeVolumePanel() {
     const backdrop = document.getElementById('volumeBackdrop');
     if (panel) panel.classList.remove('show');
     if (backdrop) backdrop.style.display = 'none';
+}
+
+// ========== 认证请求辅助 ==========
+
+/**
+ * 用插件 token 认证 fetch 资源（封面、歌词等）
+ * @param {string} url - 主程序 API 路径（如 /api/v1/songs/4/cover）
+ * @returns {Promise<Blob|null>}
+ */
+function fetchWithAuth(url) {
+    const token = getAuthToken();
+    const headers = {};
+    if (token) {
+        headers['Authorization'] = token.startsWith('Bearer ') ? token : `Bearer ${token}`;
+    }
+    return fetch(url, { headers }).then(res => {
+        if (!res.ok) throw new Error('fetch failed: ' + res.status);
+        return res.blob();
+    });
+}
+
+// ========== 歌词相关 ==========
+
+/**
+ * 获取并解析歌词
+ * @param {string} lyricUrl - 歌词 URL
+ */
+function fetchLyrics(lyricUrl) {
+    if (!lyricUrl) return;
+
+    if (lyricFetchTimer) {
+        clearTimeout(lyricFetchTimer);
+        lyricFetchTimer = null;
+    }
+
+    lyricFetchTimer = setTimeout(() => {
+        lyricFetchTimer = null;
+        fetchWithAuth(lyricUrl).then(blob => {
+            if (!blob) return;
+            blob.text().then(rawText => {
+                let lrcText = rawText;
+                try {
+                    const json = JSON.parse(rawText);
+                    if (json.lyric) {
+                        lrcText = json.lyric;
+                    } else if (json.success && json.data && json.data.lyric) {
+                        lrcText = json.data.lyric;
+                    } else if (json.data) {
+                        lrcText = typeof json.data === 'string' ? json.data : '';
+                    }
+                } catch {
+                    // 不是 JSON，直接使用原始文本
+                }
+                currentLyrics = parseLrc(lrcText);
+            });
+        }).catch(err => {
+            console.warn('获取歌词失败:', err);
+        });
+    }, 500);
+}
+
+/**
+ * HTML 转义
+ */
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
 }

--- a/static/js/playlist.js
+++ b/static/js/playlist.js
@@ -9,6 +9,24 @@ import { loadDeviceStatus } from './playback.js';
 import { initPlaylistSearch, initSongSearch } from './search.js';
 
 /**
+ * 用插件 token 认证 fetch 封面资源
+ * @param {string} url
+ * @returns {Promise<Blob|null>}
+ */
+function fetchCoverWithAuth(url) {
+    const { getAuthToken } = SongloftPlugin;
+    const token = getAuthToken();
+    const headers = {};
+    if (token) {
+        headers['Authorization'] = token.startsWith('Bearer ') ? token : `Bearer ${token}`;
+    }
+    return fetch(url, { headers }).then(res => {
+        if (!res.ok) throw new Error('fetch failed: ' + res.status);
+        return res.blob();
+    });
+}
+
+/**
  * HTML 转义辅助函数
  * @param {string} text - 需要转义的文本
  * @returns {string} 转义后的安全 HTML 文本
@@ -207,6 +225,24 @@ export function loadPlaylistSongs(playlistId) {
             const item = document.createElement('div');
             item.className = 'song-item';
             item.setAttribute('data-index', index);
+
+            // 封面 - 用认证 fetch 获取
+            if (song.cover_url) {
+                const coverImg = document.createElement('img');
+                coverImg.className = 'song-item-cover';
+                coverImg.alt = song.title;
+                // 延迟获取封面，避免阻塞列表渲染
+                fetchCoverWithAuth(song.cover_url).then(blob => {
+                    if (blob) {
+                        const reader = new FileReader();
+                        reader.onload = () => { coverImg.src = reader.result; };
+                        reader.readAsDataURL(blob);
+                    }
+                }).catch(() => {
+                    // 封面获取失败
+                });
+                item.appendChild(coverImg);
+            }
 
             // 序号
             const indexSpan = document.createElement('span');


### PR DESCRIPTION
扩展播放器数据类型以支持封面和歌词地址字段
实现带认证的资源拉取逻辑以获取受保护的媒体资源
新增LRC歌词解析与同步高亮显示功能
更新播放栏和歌曲列表的UI以展示封面和歌词信息
同步更新项目版本号与依赖包配置