### PR TITLE
Refactor/neutral import song

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miot",
-  "version": "2026.6.18",
+  "version": "2026.6.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miot",
-      "version": "2026.6.18",
+      "version": "2026.6.20",
       "devDependencies": {
         "@songloft/plugin-builder": "^2.4.3",
         "@songloft/plugin-sdk": "^2.4.3",

--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -39,6 +39,7 @@ function defaultPluginConfig(): PluginConfig {
     external_search_enabled: false,
     external_search_url: '',
     external_search_token: '',
+    external_search_playlist_id: '1',  // 默认追加到「收藏」歌单（宿主预置 id=1）
     indicator_light_enabled: true,
     interrupt_tts_hint_enabled: false,
     interrupt_tts_hint_text: '正在搜索，请稍候',

--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -86,9 +86,10 @@ export class ConfigManager {
 
   // ===== 全局配置 =====
 
-  /** 获取插件全局配置 */
+  /** 获取插件全局配置（与默认值合并，确保新增字段有默认值） */
   async getConfig(): Promise<PluginConfig> {
-    return this.load<PluginConfig>(STORAGE_KEY_CONFIG, defaultPluginConfig());
+    const stored = await this.load<Partial<PluginConfig>>(STORAGE_KEY_CONFIG, {});
+    return { ...defaultPluginConfig(), ...stored };
   }
 
   /** 保存插件全局配置 */

--- a/src/handlers/config.ts
+++ b/src/handlers/config.ts
@@ -74,6 +74,7 @@ export function registerConfigHandlers(
           external_search_enabled: !!config.external_search_enabled,
           external_search_url: config.external_search_url || '',
           external_search_token: config.external_search_token || '',
+          external_search_playlist_id: config.external_search_playlist_id ?? '1',
           extra_music_api_models: config.extra_music_api_models || [],
           indicator_light_enabled: !!config.indicator_light_enabled,
           interrupt_tts_hint_enabled: !!config.interrupt_tts_hint_enabled,
@@ -145,6 +146,13 @@ export function registerConfigHandlers(
       // 更新 external_search_enabled
       if (body.external_search_enabled !== undefined) {
         config.external_search_enabled = !!body.external_search_enabled;
+      }
+
+      // 更新 external_search_playlist_id
+      if (body.external_search_playlist_id !== undefined) {
+        config.external_search_playlist_id = typeof body.external_search_playlist_id === 'string'
+          ? body.external_search_playlist_id.trim()
+          : String(body.external_search_playlist_id);
       }
 
       // 更新 indicator_light_enabled

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,6 +92,7 @@ export interface PluginConfig {
   external_search_enabled: boolean; // 是否启用外部搜索
   external_search_url: string;      // 外部搜索 API 地址
   external_search_token: string;    // 外部搜索 Token 认证
+  external_search_playlist_id: string; // 外部搜索导入后追加到的歌单 ID，空串表示不追加
   extra_music_api_models?: string[];
   indicator_light_enabled?: boolean;
   interrupt_tts_hint_enabled: boolean;

--- a/src/voicecmd/online_searcher.ts
+++ b/src/voicecmd/online_searcher.ts
@@ -15,22 +15,19 @@ interface SearchOneRequest {
   quality?: string;
 }
 
-// 外部搜索 API 成功响应 data
-// source_data 为可选，外部接口不一定返回
+// 外部搜索 API 成功响应 data（provider 中立，不解读内部字段）
 interface SearchOneData {
   title: string;
   artist: string;
-  album: string;
-  duration: number;
-  cover_url: string;
-  url: string;
-  source_data?: LxSourceData;
-}
-
-interface LxSourceData {
-  platform: string;
-  quality: string;
-  songInfo: Record<string, unknown>;
+  album?: string;
+  duration?: number;
+  cover_url?: string;
+  url?: string;                                      // 直链型 provider 提供
+  plugin_entry_path?: string;                        // provider 自身 entryPath；缺省纯外链
+  source_data?: string | Record<string, unknown>;   // 不透明；对象则由 MIoT 序列化
+  dedup_key?: string;
+  lyric?: string;
+  lyric_source?: string;
 }
 
 // 外部搜索 API 响应
@@ -40,17 +37,19 @@ interface SearchOneResponse {
   data: SearchOneData | null;
 }
 
-// songloft /api/v1/songs/remote 请求体
+// songloft /api/v1/songs/remote 请求体（provider 中立）
 interface RemoteSongItem {
   title: string;
   artist: string;
   album: string;
   cover_url: string;
   duration: number;
-  url: string;               // 绝对 URL，lxmusic topone 已返回
-  plugin_entry_path: string; // 空字符串表示直接用 url 字段
+  url: string;               // 直链型 provider 有；解析型为空
+  plugin_entry_path: string; // provider 自身 entryPath；缺省 '' 表示纯外链
   source_data: string;
   dedup_key: string;
+  lyric?: string;
+  lyric_source?: string;
 }
 
 // songloft /api/v1/songs/remote 响应
@@ -73,7 +72,8 @@ interface RemoteSongsResponse {
 
 /**
  * 在线歌曲搜索器
- * 封装对用户配置的外部搜索 API 的调用，支持洛雪音乐等兼容接口
+ * 封装对用户配置的外部搜索 API（topone）的调用。
+ * MIoT 作为中立消费方，不解读 source_data 内部结构，不写死任何插件名。
  */
 export class OnlineSearcher {
   private readonly searchTimeoutMs = 6000;
@@ -198,6 +198,20 @@ export class OnlineSearcher {
       return false;
     }
 
+    // 入库后追加到目标歌单（可选，由配置决定）
+    const config = await this.configManager.getConfig();
+    const pid = config.external_search_playlist_id;
+    if (pid) {
+      try {
+        const plToken = await songloft.plugin.getToken();
+        await fetch(`${getHostBaseUrl()}/api/v1/playlists/${pid}/songs`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${plToken}` },
+          body: JSON.stringify({ song_ids: [imported.id] }),
+        });
+      } catch (e) { songloft.log.warn(`[OnlineSearcher] 追加歌单失败: ${String(e)}`); }
+    }
+
     // 用返回的 url 构造完整播放 URL（相对路径，URLBuilder 会拼接 server_host 和 token）
     const playUrl = await URLBuilder.buildSongURL({ id: imported.id, url: imported.url});
     if (!playUrl) {
@@ -220,34 +234,21 @@ export class OnlineSearcher {
    * @returns 导入成功后包含歌曲 id 和 url 的对象，失败返回 null
    */
   private async importSong(song: SearchOneData): Promise<{ id: number; url: string } | null> {
-    // 构造 dedup_key 用于去重（source_data 可能缺失，降级处理）
-    const sd = song.source_data;
-    const songInfo = sd?.songInfo || {};
-    const platform = sd?.platform || 'external';
-    const musicId = String(songInfo.musicId || songInfo.hash || '');
-    const dedupKey = musicId ? `${platform}_${musicId}` : '';
-
-    // 构造 source_data（存储搜索来源的原始信息），缺失时用空对象
-    const sourceData = sd
-      ? JSON.stringify({
-          platform: sd.platform,
-          quality: sd.quality,
-          musicId: musicId,
-          hash: String(songInfo.hash || ''),
-          songmid: String(songInfo.songmid || ''),
-        })
-      : '';
-
+    // provider 字段原样映射，不解读、不补插件名
     const remoteItem: RemoteSongItem = {
       title: song.title,
-      artist: song.artist,
+      artist: song.artist || '',
       album: song.album || '',
       cover_url: song.cover_url || '',
       duration: song.duration || 0,
-      url: song.url || '',  // lxmusic topone 已返回绝对 URL，后端直接代理
-      plugin_entry_path: '', // 空表示直接用 url 字段，不走插件回调
-      source_data: sourceData,
-      dedup_key: dedupKey,
+      url: song.url || '',                              // 直链型 provider 有；解析型为空
+      plugin_entry_path: song.plugin_entry_path || '',  // 中立缺省 ''，绝不写死任何插件名
+      source_data: typeof song.source_data === 'string'
+        ? song.source_data
+        : (song.source_data ? JSON.stringify(song.source_data) : ''),   // 对象则序列化，不窥内部
+      dedup_key: song.dedup_key || '',
+      lyric: song.lyric || '',
+      lyric_source: song.lyric_source || '',
     };
 
     try {

--- a/static/index.html
+++ b/static/index.html
@@ -488,16 +488,24 @@
                             <input type="text" id="externalSearchUrlInput" class="text-field" style="font-size:13px;padding:7px 10px" placeholder="https://example.com/api/search/topone 或 /api/v1/jsplugin/**" aria-label="外部搜索 API 地址">
                         </div>
                         <div style="margin-top:10px">
-                            <div style="font-size:12px;color:var(--md-on-surface-variant);margin-bottom:4px;font-weight:500">Authorization Token 认证（可选,为空则使用插件Token）</div>
-                            <input type="text" id="externalSearchTokenInput" class="text-field" style="font-size:13px;padding:7px 10px" placeholder="Bearer *****" aria-label="外部搜索认证 Token">
+                        <div class="switch-row" style="margin-top:10px">
+                            <div class="switch-row-label">
+                                <span class="switch-row-title">自动追加到歌单</span>
+                                <span class="switch-row-subtitle">语音搜歌导入后自动追加到下方指定的歌单</span>
+                            </div>
+                            <label class="switch">
+                                <input type="checkbox" id="externalSearchAppendPlaylistSwitch" aria-label="自动追加到歌单">
+                                <span class="switch-slider"></span>
+                            </label>
+                        </div>
+                        <div id="externalSearchPlaylistPanel" style="margin-top:10px; display:none">
+                            <div style="font-size:12px;color:var(--md-on-surface-variant);margin-bottom:4px;font-weight:500">选择目标歌单</div>
+                            <select id="externalSearchPlaylistSelect" class="text-field" style="width:100%" aria-label="目标歌单">
+                                <option value="">-- 加载中 --</option>
+                            </select>
                         </div>
                     </div>
-                    <div class="toolbar" style="padding:12px 0 0;justify-content:flex-end">
-                        <button class="btn-filled" id="saveExternalSearchBtn">
-                            <span class="material-symbols-outlined">save</span>
-                            保存配置
-                        </button>
-                    </div>
+
                     <div style="margin-top:12px;padding:10px 12px;background:rgba(0,0,0,0.03);border-radius:6px">
                         <div style="font-size:12px;color:var(--md-on-surface-variant);margin-bottom:6px;font-weight:500">接口测试</div>
                         <div style="display:flex;gap:6px">

--- a/static/js/config.js
+++ b/static/js/config.js
@@ -98,6 +98,27 @@ export function loadConfig() {
             if (externalSearchTokenInput) {
                 externalSearchTokenInput.value = data.data.external_search_token || '';
             }
+            const externalSearchAppendSwitch = document.getElementById('externalSearchAppendPlaylistSwitch');
+            const externalSearchPlaylistPanel = document.getElementById('externalSearchPlaylistPanel');
+            const externalSearchPlaylistSelect = document.getElementById('externalSearchPlaylistSelect');
+            if (externalSearchAppendSwitch && externalSearchPlaylistSelect && externalSearchPlaylistPanel) {
+                const savedPid = data.data.external_search_playlist_id;
+                const isAppending = !!savedPid;
+                externalSearchAppendSwitch.checked = isAppending;
+                externalSearchPlaylistPanel.style.display = isAppending ? 'block' : 'none';
+
+                apiGet('/playlists?limit=500').then(res => {
+                    if (res.success && res.data) {
+                        externalSearchPlaylistSelect.innerHTML = res.data.map(p => 
+                            `<option value="${p.id}" ${String(p.id) === String(savedPid) ? 'selected' : ''}>${escapeHtml(p.name)}</option>`
+                        ).join('');
+                    } else {
+                        externalSearchPlaylistSelect.innerHTML = '<option value="">-- 获取歌单失败 --</option>';
+                    }
+                }).catch(() => {
+                    externalSearchPlaylistSelect.innerHTML = '<option value="">-- 获取歌单失败 --</option>';
+                });
+            }
             updateExternalSearchDependency();
 
             // 搜索提示 TTS 配置
@@ -293,18 +314,21 @@ function updateExternalSearchConfig(enabled) {
     }
 }
 
-function saveExternalSearchConfig() {
+function saveExternalSearchConfig(silent = false) {
     const switchEl = document.getElementById('externalSearchSwitch');
     const urlInput = document.getElementById('externalSearchUrlInput');
     const tokenInput = document.getElementById('externalSearchTokenInput');
+    const appendSwitch = document.getElementById('externalSearchAppendPlaylistSwitch');
+    const playlistSelect = document.getElementById('externalSearchPlaylistSelect');
     const enabled = switchEl ? switchEl.checked : false;
     const url = urlInput ? urlInput.value.trim() : '';
     const token = tokenInput ? tokenInput.value.trim() : '';
+    const playlistId = (appendSwitch && appendSwitch.checked && playlistSelect) ? playlistSelect.value : '';
 
-    apiPost('/config', { external_search_enabled: enabled, external_search_url: url, external_search_token: token })
+    apiPost('/config', { external_search_enabled: enabled, external_search_url: url, external_search_token: token, external_search_playlist_id: playlistId })
         .then(data => {
             if (data.success) {
-                showSnackbar('外部搜索配置已保存', 'success');
+                if (!silent) showSnackbar('外部搜索配置已保存', 'success');
             } else {
                 showSnackbar('保存失败：' + (data.error || '未知错误'), 'error');
             }
@@ -331,13 +355,29 @@ export function initExternalSearchUI() {
                 }
             }
             updateExternalSearchConfig(this.checked);
+            saveExternalSearchConfig(true);
         });
     }
 
-    const saveBtn = document.getElementById('saveExternalSearchBtn');
-    if (saveBtn) {
-        saveBtn.addEventListener('click', saveExternalSearchConfig);
+    const appendSwitch = document.getElementById('externalSearchAppendPlaylistSwitch');
+    if (appendSwitch) {
+        appendSwitch.addEventListener('change', function() {
+            const panel = document.getElementById('externalSearchPlaylistPanel');
+            if (panel) {
+                panel.style.display = this.checked ? 'block' : 'none';
+            }
+            saveExternalSearchConfig(true);
+        });
     }
+
+    const urlInput = document.getElementById('externalSearchUrlInput');
+    if (urlInput) urlInput.addEventListener('change', () => saveExternalSearchConfig(true));
+    
+    const tokenInput = document.getElementById('externalSearchTokenInput');
+    if (tokenInput) tokenInput.addEventListener('change', () => saveExternalSearchConfig(true));
+
+    const playlistSelect = document.getElementById('externalSearchPlaylistSelect');
+    if (playlistSelect) playlistSelect.addEventListener('change', () => saveExternalSearchConfig(true));
 
     const testBtn = document.getElementById('externalSearchTestBtn');
     const testInput = document.getElementById('externalSearchTestInput');


### PR DESCRIPTION
## 问题背景

1. **解析型插件播放超时**：`importSong` 中覆盖了入库的 `plugin_entry_path`，导致需要运行时解析直链的插件无法路由到自身的解析方法。
2. **`source_data` 解析错误**：原逻辑假定 `source_data` 必为 JSON 字符串并进行了特定的结构化转换。这会导致返回 Object 结构的第三方插件数据被破坏，入库后无法正常读取。
3. **配置合并逻辑缺失**：`manager.ts` 读取本地配置时未与默认值合并，导致升级后新增的 `external_search_playlist_id` 字段读取为 `undefined`，引起追加歌单逻辑失效。
4. **配置页交互不便**：追加歌单需要手动输入歌单 ID；外部搜索面板需要手动点击保存按钮。

## 修复内容

1. **解除 Provider 数据耦合**：
   - 移除特定结构的类型强制转换。
   - `importSong` 改为直接透传 `source_data`、`plugin_entry_path`、`dedup_key` 和 `lyric` 相关字段，保留原插件的数据结构和路由标识。
2. **修复配置加载**：
   - `manager.ts` 的 `getConfig()` 增加 `{ ...defaultPluginConfig(), ...stored }` 合并逻辑，保证新增字段的默认值正常生效。
3. **重构前端交互**：
   - 将歌单 ID 输入框替换为 `<select>` 下拉列表，通过调用 `GET /playlists` 接口拉取用户歌单数据。
   - 增加独立开关，控制是否启用自动追加。
