### PR TITLE
fix(device): 修复小爱音箱Pro(LX06)被遗漏的问题

### DIFF
--- a/src/mina/constants.ts
+++ b/src/mina/constants.ts
@@ -66,7 +66,7 @@ export const NEED_USE_PLAY_MUSIC_API: Record<string, boolean> = {
   'LX04': true,
   'L05B': true,
   'L05C': true,
-  'L06': true,
+  'LX06': true,
   'L06A': true,
   'X08A': true,
   'X10A': true,


### PR DESCRIPTION
## 背景
由于硬件型号映射字典中将小爱音箱 Pro 的代号 `LX06` 误写为了 `L06`，导致该旗舰机型无法命中 `player_play_music` 现代流媒体接口，被降级使用已被小米底层废弃的 `player_play_url` 裸链接口。
## 修复
在 `NEED_USE_PLAY_MUSIC_API` 白名单中：
- 将错误的 `L06` 修正为 `LX06` (小爱音箱 Pro)
- 补充保留 `L06A` 