### PR TITLE
feat(miot): 新增 /mina/stop 停止播放接口

### DIFF
--- a/src/handlers/device.ts
+++ b/src/handlers/device.ts
@@ -27,6 +27,7 @@ function parseBody(req: HTTPRequest): any {
  * POST /mina/play-url        → 播放URL
  * POST /mina/pause           → 暂停播放
  * POST /mina/resume          → 恢复播放
+ * POST /mina/stop            → 停止播放
  * POST /mina/device/managed  → 更新管理状态
  * POST /mina/last_selection  → 记录最后选中设备
  */
@@ -183,6 +184,28 @@ export function registerDeviceHandlers(
       }
       updateDeviceStatusCache(account_id, device_id, { state: 'playing' });
       return jsonResponse({ success: true, data: { message: 'resumed' } });
+    } catch (e: any) {
+      return jsonResponse({ success: false, error: e.message || String(e) });
+    }
+  });
+
+  // POST /mina/stop - 停止播放
+  router.post('/mina/stop', async (req: HTTPRequest) => {
+    try {
+      const body = parseBody(req);
+      const { account_id, device_id } = body;
+      if (!account_id) {
+        return jsonResponse({ success: false, error: 'account_id is required' });
+      }
+      if (!device_id) {
+        return jsonResponse({ success: false, error: 'device_id is required' });
+      }
+      const ok = await minaService.stopPlay(account_id, device_id);
+      if (!ok) {
+        return jsonResponse({ success: false, error: 'failed to stop' });
+      }
+      updateDeviceStatusCache(account_id, device_id, { state: 'stopped', position: 0 });
+      return jsonResponse({ success: true, data: { message: 'stopped' } });
     } catch (e: any) {
       return jsonResponse({ success: false, error: e.message || String(e) });
     }


### PR DESCRIPTION
## 修改内容

- 新增 `POST /mina/stop` 设备控制接口。
- 接口内部调用已有的 `minaService.stopPlay(account_id, device_id)`。
- 停止成功后同步更新设备状态缓存：
  - `state: 'stopped'`
  - `position: 0`

## 修改原因

当前 `/mina/play-url` 用于直接播放音频 URL，但缺少对应的设备级停止接口。  
外部插件或宿主在使用 `/mina/play-url` 投送直链播放时，不能通过 `/player/stop` 稳定停止该播放链路。

新增 `/mina/stop` 后，调用方可以直接停止当前音箱播放状态，和 `/mina/play-url`、`/mina/pause`、`/mina/resume` 形成一致的设备级控制接口。

## 测试

- `npx tsc --noEmit`