### PR TITLE
feat: 增强语音记忆能力，引入 V2 实体解析机制

### DIFF
--- a/docs/memory-v2-design.md
+++ b/docs/memory-v2-design.md
@@ -1,0 +1,160 @@
+# Voice Memory V2.0 Design
+
+## Scope
+
+Voice Memory V2.0 adds conservative local entity matching on top of the existing V1 exact-query memory. It does not use a local model, embeddings, a vector database, an external service, runtime `segmentit`, or new npm dependencies.
+
+The storage backend remains `songloft.storage`. The storage key remains `memory:v1:records`, and the snapshot envelope remains `version: 1`.
+
+## Runtime Order
+
+The real voice path is:
+
+1. VoiceEngine enabled check and query extraction.
+2. Built-in pause/stop aliases and configured fixed control commands.
+3. Voice Memory configuration read inside a fallback boundary.
+4. V1 `normalizedQuery` exact lookup.
+5. V2 local entity resolution.
+6. Existing song or playlist rule matching.
+7. AI fallback only when no search rule matched.
+8. Existing smart-resume behavior when nothing handled the query.
+
+Any configuration, storage, normalization, index, resolver, or memory-playback failure returns to the existing rule and AI path. Fixed controls always run before V1 and V2 memory.
+
+## V1 And V2
+
+V1 keeps the existing `normalizeQuery()` and `findByQuery()` behavior. An exact V1 hit is attempted first and is not rescored by V2.
+
+V2 runs only after a V1 miss. It strips explicit playback wrappers from the beginning or end of the query, then compares the semantic text with entities derived from successful memory records. It does not attempt general Chinese language parsing.
+
+## Persisted Data
+
+All V1 fields remain unchanged. V2 adds only two optional record fields:
+
+```ts
+recordVersion?: 2;
+canonicalKey?: string;
+```
+
+Normalized title and artist, pinyin, aliases, success ratio, and playability are derived in memory and are not written to the snapshot.
+
+## Canonical Keys
+
+Canonical keys never contain a query, URL, playlist ID, song index, or timestamp.
+
+The current priority is:
+
+1. `song:id:<songId>` when a stable Songloft song ID exists.
+2. An existing trusted `song:external:` key when a future provider identity is available in the record.
+3. `song:meta:<escapedTitle>|<escapedArtist>|<escapedAlbum>` otherwise.
+
+V1 has no album field, so its metadata key uses an empty third component. Key parts use deterministic built-in escaping; no crypto or hash dependency is added.
+
+Records with the same exact title and artist metadata are associated with a single known song-ID entity when that metadata maps to exactly one song ID. Conflicting IDs remain separate entities and trigger ambiguity protection.
+
+## Query Normalization
+
+V2 performs lightweight full-width ASCII folding, lowercasing, whitespace removal, and decorative punctuation removal. The character `的` is retained.
+
+Playback wrappers are matched longest-first and only at the start of the query. Examples include `帮我播放一下`, `帮我放一下`, `给我播放`, `我想听`, `我要听`, `来一首`, `播放`, `来首`, and `放`.
+
+Only longer, explicit polite suffixes are removed. Short suffixes such as `一下`, `吧`, and `啊` are deliberately retained because they can be part of a real song title. `歌曲` and `音乐` are not globally removed, preserving titles such as `歌曲中的故事` and `音乐之声`.
+
+## Entity Index
+
+The in-memory index contains:
+
+- `exactQueryIndex`: normalized query to record.
+- `recordById`: record ID to record.
+- `canonicalIndex`: canonical key to record-ID set.
+- `titleIndex`: normalized title to canonical-key set.
+- `artistTitleIndex`: normalized artist and title to canonical-key set.
+- `aliasIndex`: conservative alias to canonical-key set.
+- `pinyinIndex`: pinyin alias to canonical-key set, candidate generation only.
+- `derivedByRecordId`: transient normalized and reliability data.
+
+All uniqueness and candidate counts use canonical entities, not raw record counts. The index is rebuilt from the committed records after load and every successful mutation.
+
+## Representative Selection
+
+An entity can contain multiple learned queries. Its playback representative is selected deterministically by:
+
+1. Complete playback location.
+2. Higher `successCount`.
+3. Lower failure rate.
+4. Newer `lastUsedAt`.
+5. Newer `updatedAt`.
+
+The resolver never selects the first Map entry at random.
+
+## Alias Policy
+
+Each entity generates at most six aliases:
+
+- Exact song title.
+- Full artist plus title.
+- Full artist plus `的` plus title.
+- Unique conservative artist short name plus title.
+- Unique conservative short name plus `的` plus title.
+
+A Chinese artist short name is generated only for an all-Chinese name of at least three characters. It uses the final two characters and is enabled only when those characters identify one full artist across the current memory index. Two-character and English artist names do not get automatic short names. A short artist name never works without an exact song title.
+
+## Candidate Generation And Safety Gate
+
+Exact aliases and titles generate candidates first. Pinyin exact matches and bounded edit-distance checks can add candidates, but cannot directly play a song. Edit distance examines no more than 20 candidates selected from nearby title-length buckets.
+
+Evidence scores are capped at 1.0:
+
+- Exact title: `0.78`.
+- Full artist: `+0.18`.
+- Unique conservative artist short name: `+0.12`.
+- Globally unique title when no artist is supplied: `+0.18`.
+- Explicit wrapper removed: `+0.02`.
+- Reliable successful history: up to `+0.02`.
+- Pinyin title only: at most `0.68`.
+- Edit-distance title only: at most `0.65`.
+
+Direct playback requires score at least `0.92`, top-candidate margin at least `0.08`, one clear canonical entity, at least one prior success, failure rate below `0.5`, `play_song` type, playable metadata, exact-title evidence, and either artist evidence or a globally unique title. Single-character titles, pinyin-only evidence, homophones, edit-distance-only evidence, and artist-short-name-only input always fall back.
+
+## Duplicate Titles
+
+If the same title belongs to multiple canonical entities, a title-only query returns `ambiguous`. A full artist name or a unique conservative artist short name plus the exact title is required. Multiple query records for one canonical entity still count as one song.
+
+A record without an artist forms a separate metadata entity. It cannot make a title shared by known artists appear unique.
+
+## Lazy Migration
+
+V1 records are indexed in memory without an eager storage rewrite. Records without a song name continue to support V1 exact lookup but are excluded from V2 entities.
+
+After an old record succeeds through V1 or V2, the normal serialized `recordSuccess()` transaction stores `recordVersion: 2` and its canonical key. A V2 alias hit also learns the new query as a future V1 exact query while updating the matched representative.
+
+## Transactional Writes
+
+All mutations share a Promise write queue. Each operation waits for its predecessor, copies the committed Map, modifies and prunes the copy, writes a complete snapshot, and swaps the official Map only after a successful save. The entity index is then rebuilt from the committed Map.
+
+This applies to success and failure recording, deletion, clearing, maximum-record changes, trimming, and automatic eviction. A failed save leaves the committed records and indexes unchanged. A rejected queue operation is caught so later writes can continue.
+
+## Read Failure Protection
+
+Storage loading distinguishes a missing key, a valid empty snapshot, a storage read error, and an invalid snapshot. Read and format errors put MemoryService in a degraded state: V1 and V2 miss, writes are refused, and the existing rule and AI paths continue.
+
+An invalid record can be ignored without discarding valid records. A non-empty snapshot containing no valid records is treated as a format error and is never automatically replaced with an empty snapshot.
+
+## Resource Impact
+
+The configured maximum remains 10 to 1000 records. Alias count is bounded, edit-distance candidates are capped at 20, and pinyin uses the existing generated lookup map. The runtime does not initialize `segmentit` or `pinyin-pro` dictionaries.
+
+The built-in pure self-test covers exact matching, entity aliases, duplicate titles, homophones, migration compatibility, mutation rollback, queue recovery, concurrency, index cleanup, and 10/100/1000-record performance.
+
+## External Playback Limitation
+
+No change is made to `online_searcher.ts`. Imported external playback currently returns only success to VoiceEngine, so some successful memories contain title and artist but no Songloft song ID. Those records receive a stable metadata canonical key and replay through the existing title-and-artist search path.
+
+No-import direct playback never stores a temporary URL. If the resource cannot later be resolved by existing search, memory playback fails safely and falls back to the normal rule and external-search flow.
+
+## Known Limits
+
+- Pinyin uses a single generated reading per character and is candidate-only.
+- Metadata keys cannot distinguish two versions with the same title and artist when no ID or album is available.
+- Existing song-rule execution still returns after a matched rule even if that rule's playback fails; V2 does not broaden that historical behavior.
+- VoiceEngine ordering, disabled-memory behavior, and playback fallback require runtime verification with real voice input in addition to the pure self-test.

--- a/src/handlers/config.ts
+++ b/src/handlers/config.ts
@@ -326,7 +326,7 @@ export function registerConfigHandlers(
       let memoryWarning = '';
       if (memoryMaxChanged) {
         try {
-          memoryService.setMaxRecords(config.voice_memory_max_records);
+          await memoryService.setMaxRecords(config.voice_memory_max_records);
           await memoryService.init();
           if (!(await memoryService.trimToLimit())) {
             memoryWarning = '最大记忆数量已保存，但现有记忆暂时无法完成淘汰。';

--- a/src/handlers/memory.ts
+++ b/src/handlers/memory.ts
@@ -4,7 +4,8 @@ import { jsonResponse, parseQuery } from '@songloft/plugin-sdk';
 import type { Router, HTTPRequest } from '@songloft/plugin-sdk';
 import { MemoryService } from '../memory';
 import type { ConfigManager } from '../config/manager';
-import type { MemoryRecord, MemoryStorageAdapter, MemoryStoreSnapshot } from '../memory';
+import type { MemoryLoadResult, MemoryRecord, MemoryStorageAdapter, MemoryStoreSnapshot } from '../memory';
+import { runMemoryV2SelfTest } from '../memory/self_test';
 
 const MEMORY_STORAGE_KEY = 'memory:v1:records';
 
@@ -54,25 +55,27 @@ function isMemoryRecord(value: unknown): value is MemoryRecord {
     typeof value.failureCount === 'number' &&
     typeof value.createdAt === 'string' &&
     typeof value.updatedAt === 'string' &&
-    typeof value.lastUsedAt === 'string'
+    typeof value.lastUsedAt === 'string' &&
+    (value.query === undefined || typeof value.query === 'string') &&
+    (value.recordVersion === undefined || value.recordVersion === 2) &&
+    (value.canonicalKey === undefined || typeof value.canonicalKey === 'string')
   );
 }
 
 function parseSnapshot(raw: unknown): MemoryStoreSnapshot {
-  try {
-    const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
-    if (!isObject(parsed) || parsed.version !== 1 || !Array.isArray(parsed.records)) {
-      return emptySnapshot();
-    }
-
-    return {
-      version: 1,
-      records: parsed.records.filter(isMemoryRecord),
-      updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : new Date().toISOString(),
-    };
-  } catch {
-    return emptySnapshot();
+  const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+  if (!isObject(parsed) || parsed.version !== 1 || !Array.isArray(parsed.records)) {
+    throw new Error('invalid memory snapshot envelope');
   }
+  const records = parsed.records.filter(isMemoryRecord);
+  if (parsed.records.length > 0 && records.length === 0) {
+    throw new Error('memory snapshot contains no valid records');
+  }
+  return {
+    version: 1,
+    records,
+    updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : new Date().toISOString(),
+  };
 }
 
 function normalizeErrorText(message: string): string {
@@ -154,17 +157,23 @@ class SelfTestStorageAdapter implements MemoryStorageAdapter {
     this.lastError = null;
   }
 
-  async load(): Promise<MemoryStoreSnapshot> {
+  async load(): Promise<MemoryLoadResult> {
+    let raw: unknown;
     try {
       this.clearLastError();
-      const raw = await songloft.storage.get(MEMORY_STORAGE_KEY);
-      if (raw === null || raw === undefined || raw === '') {
-        return emptySnapshot();
-      }
-      return parseSnapshot(raw);
+      raw = await songloft.storage.get(MEMORY_STORAGE_KEY);
     } catch (error) {
       this.lastError = toErrorDetails(error);
-      throw error;
+      return { status: 'read_error', error: this.lastError.message };
+    }
+    if (raw === null || raw === undefined || raw === '') {
+      return { status: 'missing', snapshot: emptySnapshot() };
+    }
+    try {
+      return { status: 'ok', snapshot: parseSnapshot(raw) };
+    } catch (error) {
+      this.lastError = toErrorDetails(error);
+      return { status: 'format_error', error: this.lastError.message };
     }
   }
 
@@ -191,7 +200,7 @@ export function registerMemoryHandlers(
 ): void {
   const ensureMemoryReady = async (): Promise<void> => {
     const config = await configManager.getConfig();
-    memoryService.setMaxRecords(config.voice_memory_max_records);
+    await memoryService.setMaxRecords(config.voice_memory_max_records);
     await memoryService.init();
   };
 
@@ -314,7 +323,11 @@ export function registerMemoryHandlers(
       };
 
       try {
-        originalSnapshot = await adapter.load();
+        const originalLoad = await adapter.load();
+        originalSnapshot = originalLoad.snapshot ?? null;
+        if (!originalSnapshot) {
+          throw new Error(originalLoad.error || `storage load failed: ${originalLoad.status}`);
+        }
         steps['load-original'] = { ok: true, message: '已读取原始记忆快照' };
       } catch (error) {
         const errorDetails = adapter.getLastError() ?? toErrorDetails(error);
@@ -425,6 +438,14 @@ export function registerMemoryHandlers(
         failureCount: foundAfterFailure.failureCount,
       } : null;
       logStep('recordFailure', 'success', 'recordFailure 调用成功');
+
+      const v2Result = await runMemoryV2SelfTest();
+      details.v2 = v2Result;
+      if (!v2Result.ok) {
+        await restoreOriginalSnapshot();
+        logStep('done', 'failed', 'V2 实体匹配自测失败');
+        return makeResponse(false, 'done', 'V2 实体匹配自测失败', details);
+      }
 
       await restoreOriginalSnapshot();
       if (!steps.restore.ok) {

--- a/src/memory/entity_index.ts
+++ b/src/memory/entity_index.ts
@@ -1,0 +1,213 @@
+import type { MemoryRecord } from './types';
+import { compactPinyin, isChineseName, normalizeEntityText, readableKeyPart } from './query_normalizer';
+
+const MAX_ALIASES_PER_ENTITY = 6;
+const MAX_FUZZY_CANDIDATES = 20;
+
+export interface DerivedMemoryRecord {
+  record: MemoryRecord;
+  canonicalKey: string;
+  normalizedTitle: string;
+  normalizedArtist: string;
+  titlePinyin: string;
+  artistPinyin: string;
+  aliases: string[];
+  successRatio: number;
+  playable: boolean;
+}
+
+export interface MemoryEntity {
+  canonicalKey: string;
+  recordIds: Set<string>;
+  representative: MemoryRecord;
+  normalizedTitle: string;
+  normalizedArtist: string;
+  titlePinyin: string;
+  artistPinyin: string;
+  shortArtist?: string;
+  aliases: string[];
+}
+
+function addIndex(index: Map<string, Set<string>>, key: string, canonicalKey: string): void {
+  if (!key) return;
+  const values = index.get(key) ?? new Set<string>();
+  values.add(canonicalKey);
+  index.set(key, values);
+}
+
+function playbackRank(record: MemoryRecord): number {
+  if (typeof record.playlistId === 'number' && typeof record.songIndex === 'number') return 3;
+  if (typeof record.songId === 'number') return 2;
+  if (record.songName) return 1;
+  return 0;
+}
+
+function failureRate(record: MemoryRecord): number {
+  const total = record.successCount + record.failureCount;
+  return total > 0 ? record.failureCount / total : 1;
+}
+
+function compareRepresentative(a: MemoryRecord, b: MemoryRecord): number {
+  const playback = playbackRank(b) - playbackRank(a);
+  if (playback !== 0) return playback;
+  const success = b.successCount - a.successCount;
+  if (success !== 0) return success;
+  const failure = failureRate(a) - failureRate(b);
+  if (failure !== 0) return failure;
+  const lastUsed = b.lastUsedAt.localeCompare(a.lastUsedAt);
+  if (lastUsed !== 0) return lastUsed;
+  return b.updatedAt.localeCompare(a.updatedAt);
+}
+
+export function canonicalKeyForRecord(record: Pick<MemoryRecord, 'songId' | 'songName' | 'artist' | 'canonicalKey'>): string {
+  if (typeof record.songId === 'number' && Number.isFinite(record.songId)) {
+    return `song:id:${record.songId}`;
+  }
+  if (record.canonicalKey?.startsWith('song:external:')) {
+    return record.canonicalKey;
+  }
+  const title = normalizeEntityText(record.songName || '');
+  const artist = normalizeEntityText(record.artist || '');
+  if (!title) return '';
+  // Album is not present in V1 records, so the third metadata component is intentionally empty.
+  return `song:meta:${readableKeyPart(title)}|${readableKeyPart(artist)}|`;
+}
+
+export class MemoryEntityIndex {
+  readonly exactQueryIndex = new Map<string, MemoryRecord>();
+  readonly recordById = new Map<string, MemoryRecord>();
+  readonly canonicalIndex = new Map<string, Set<string>>();
+  readonly titleIndex = new Map<string, Set<string>>();
+  readonly artistTitleIndex = new Map<string, Set<string>>();
+  readonly aliasIndex = new Map<string, Set<string>>();
+  readonly pinyinIndex = new Map<string, Set<string>>();
+  readonly derivedByRecordId = new Map<string, DerivedMemoryRecord>();
+  readonly entities = new Map<string, MemoryEntity>();
+  private titleLengthIndex = new Map<string, Set<string>>();
+
+  rebuild(records: Iterable<MemoryRecord>): void {
+    this.clear();
+    const playableRecords = Array.from(records).filter(record => {
+      this.exactQueryIndex.set(record.normalizedQuery, record);
+      this.recordById.set(record.id, record);
+      return record.type === 'play_song' && !!record.songName;
+    });
+
+    const metadataIdKeys = new Map<string, Set<string>>();
+    for (const record of playableRecords) {
+      if (typeof record.songId !== 'number') continue;
+      const title = normalizeEntityText(record.songName || '');
+      const artist = normalizeEntityText(record.artist || '');
+      const metadataKey = `${title}\u0000${artist}`;
+      addIndex(metadataIdKeys, metadataKey, `song:id:${record.songId}`);
+    }
+
+    const prelim = playableRecords.map(record => {
+      const normalizedTitle = normalizeEntityText(record.songName || '');
+      const normalizedArtist = normalizeEntityText(record.artist || '');
+      let canonicalKey = canonicalKeyForRecord(record);
+      if (typeof record.songId !== 'number') {
+        const idKeys = metadataIdKeys.get(`${normalizedTitle}\u0000${normalizedArtist}`);
+        if (idKeys?.size === 1) canonicalKey = Array.from(idKeys)[0];
+      }
+      return { record, normalizedTitle, normalizedArtist, canonicalKey };
+    }).filter(item => !!item.canonicalKey && !!item.normalizedTitle);
+
+    const shortArtists = new Map<string, Set<string>>();
+    for (const item of prelim) {
+      if (!isChineseName(item.normalizedArtist)) continue;
+      const shortName = Array.from(item.normalizedArtist).slice(-2).join('');
+      const artists = shortArtists.get(shortName) ?? new Set<string>();
+      artists.add(item.normalizedArtist);
+      shortArtists.set(shortName, artists);
+    }
+
+    const grouped = new Map<string, typeof prelim>();
+    for (const item of prelim) {
+      const items = grouped.get(item.canonicalKey) ?? [];
+      items.push(item);
+      grouped.set(item.canonicalKey, items);
+    }
+
+    for (const [canonicalKey, items] of grouped) {
+      const sorted = items.slice().sort((a, b) => compareRepresentative(a.record, b.record));
+      const primary = sorted[0];
+      const metadataSource = sorted.find(item => item.normalizedArtist) ?? primary;
+      const recordIds = new Set(items.map(item => item.record.id));
+      const normalizedArtist = metadataSource.normalizedArtist;
+      const shortName = isChineseName(normalizedArtist)
+        ? Array.from(normalizedArtist).slice(-2).join('')
+        : '';
+      const shortArtist = shortName && shortArtists.get(shortName)?.size === 1 ? shortName : undefined;
+      const aliases = [
+        primary.normalizedTitle,
+        normalizedArtist + primary.normalizedTitle,
+        normalizedArtist ? `${normalizedArtist}的${primary.normalizedTitle}` : '',
+        shortArtist ? shortArtist + primary.normalizedTitle : '',
+        shortArtist ? `${shortArtist}的${primary.normalizedTitle}` : '',
+      ].filter((value, index, all) => !!value && all.indexOf(value) === index)
+        .slice(0, MAX_ALIASES_PER_ENTITY);
+
+      const entity: MemoryEntity = {
+        canonicalKey,
+        recordIds,
+        representative: primary.record,
+        normalizedTitle: primary.normalizedTitle,
+        normalizedArtist,
+        titlePinyin: compactPinyin(primary.normalizedTitle),
+        artistPinyin: compactPinyin(normalizedArtist),
+        shortArtist,
+        aliases,
+      };
+      this.entities.set(canonicalKey, entity);
+      this.canonicalIndex.set(canonicalKey, recordIds);
+      addIndex(this.titleIndex, entity.normalizedTitle, canonicalKey);
+      addIndex(this.artistTitleIndex, `${entity.normalizedArtist}\u0000${entity.normalizedTitle}`, canonicalKey);
+      addIndex(this.titleLengthIndex, String(Array.from(entity.normalizedTitle).length), canonicalKey);
+
+      for (const alias of aliases) {
+        addIndex(this.aliasIndex, alias, canonicalKey);
+        addIndex(this.pinyinIndex, compactPinyin(alias), canonicalKey);
+      }
+
+      for (const item of items) {
+        const successTotal = item.record.successCount + item.record.failureCount;
+        this.derivedByRecordId.set(item.record.id, {
+          record: item.record,
+          canonicalKey,
+          normalizedTitle: item.normalizedTitle,
+          normalizedArtist: item.normalizedArtist,
+          titlePinyin: compactPinyin(item.normalizedTitle),
+          artistPinyin: compactPinyin(item.normalizedArtist),
+          aliases,
+          successRatio: successTotal > 0 ? item.record.successCount / successTotal : 0,
+          playable: playbackRank(item.record) > 0,
+        });
+      }
+    }
+  }
+
+  getFuzzyCandidates(titleLength: number): string[] {
+    const result: string[] = [];
+    for (let length = Math.max(2, titleLength - 1); length <= titleLength + 1; length++) {
+      for (const key of this.titleLengthIndex.get(String(length)) ?? []) {
+        if (!result.includes(key)) result.push(key);
+        if (result.length >= MAX_FUZZY_CANDIDATES) return result;
+      }
+    }
+    return result;
+  }
+
+  clear(): void {
+    this.exactQueryIndex.clear();
+    this.recordById.clear();
+    this.canonicalIndex.clear();
+    this.titleIndex.clear();
+    this.artistTitleIndex.clear();
+    this.aliasIndex.clear();
+    this.pinyinIndex.clear();
+    this.derivedByRecordId.clear();
+    this.entities.clear();
+    this.titleLengthIndex.clear();
+  }
+}

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -1,3 +1,7 @@
 export * from './types';
 export { SongloftStorageMemoryAdapter } from './storage_adapter';
 export { MemoryService } from './memory_service';
+export { MemoryEntityIndex, canonicalKeyForRecord } from './entity_index';
+export { MemoryResolver } from './memory_resolver';
+export { normalizeEntityText, normalizeMemoryQuery } from './query_normalizer';
+export { runMemoryV2SelfTest } from './self_test';

--- a/src/memory/memory_resolver.ts
+++ b/src/memory/memory_resolver.ts
@@ -1,0 +1,172 @@
+import type { MemoryResolveResult } from './types';
+import type { MemoryEntity } from './entity_index';
+import { MemoryEntityIndex } from './entity_index';
+import { normalizeMemoryQuery } from './query_normalizer';
+
+const DIRECT_SCORE_THRESHOLD = 0.92;
+const DIRECT_MARGIN_THRESHOLD = 0.08;
+
+interface ScoredCandidate {
+  entity: MemoryEntity;
+  score: number;
+  exactTitle: boolean;
+  fullArtist: boolean;
+  shortArtist: boolean;
+  reason: string;
+}
+
+function levenshtein(a: string, b: string): number {
+  const aa = Array.from(a);
+  const bb = Array.from(b);
+  let previous = Array.from({ length: bb.length + 1 }, (_, i) => i);
+  let current = new Array<number>(bb.length + 1);
+  for (let i = 1; i <= aa.length; i++) {
+    current[0] = i;
+    for (let j = 1; j <= bb.length; j++) {
+      current[j] = Math.min(
+        current[j - 1] + 1,
+        previous[j] + 1,
+        previous[j - 1] + (aa[i - 1] === bb[j - 1] ? 0 : 1),
+      );
+    }
+    const swap = previous;
+    previous = current;
+    current = swap;
+  }
+  return previous[bb.length];
+}
+
+function similarity(a: string, b: string): number {
+  const maxLength = Math.max(Array.from(a).length, Array.from(b).length);
+  return maxLength === 0 ? 1 : 1 - levenshtein(a, b) / maxLength;
+}
+
+function historyBonus(entity: MemoryEntity): number {
+  if (entity.representative.successCount >= 3) return 0.02;
+  if (entity.representative.successCount >= 1) return 0.01;
+  return 0;
+}
+
+function failureRate(entity: MemoryEntity): number {
+  const record = entity.representative;
+  const total = record.successCount + record.failureCount;
+  return total > 0 ? record.failureCount / total : 1;
+}
+
+export class MemoryResolver {
+  constructor(private readonly index: MemoryEntityIndex) {}
+
+  resolve(query: string): MemoryResolveResult {
+    const normalized = normalizeMemoryQuery(query);
+    const semantic = normalized.semanticText;
+    if (!semantic) return { status: 'miss', reason: 'empty_semantic_text', candidateCount: 0 };
+
+    const candidateKeys = new Set<string>();
+    for (const key of this.index.aliasIndex.get(semantic) ?? []) candidateKeys.add(key);
+    for (const key of this.index.titleIndex.get(semantic) ?? []) candidateKeys.add(key);
+    for (const key of this.index.pinyinIndex.get(normalized.pinyin) ?? []) candidateKeys.add(key);
+    for (const key of this.index.getFuzzyCandidates(Array.from(semantic).length)) candidateKeys.add(key);
+
+    const scored: ScoredCandidate[] = [];
+    for (const canonicalKey of candidateKeys) {
+      const entity = this.index.entities.get(canonicalKey);
+      if (!entity) continue;
+
+      const exactTitle = semantic === entity.normalizedTitle;
+      const fullArtist = !!entity.normalizedArtist && (
+        semantic === entity.normalizedArtist + entity.normalizedTitle ||
+        semantic === `${entity.normalizedArtist}的${entity.normalizedTitle}`
+      );
+      const shortArtist = !!entity.shortArtist && (
+        semantic === entity.shortArtist + entity.normalizedTitle ||
+        semantic === `${entity.shortArtist}的${entity.normalizedTitle}`
+      );
+      const pinyinTitle = !exactTitle && normalized.pinyin === entity.titlePinyin;
+      let score = exactTitle || fullArtist || shortArtist ? 0.78 : 0;
+      let reason = exactTitle ? 'exact_title' : fullArtist ? 'full_artist_title' : shortArtist ? 'unique_short_artist_title' : '';
+
+      if (fullArtist) score += 0.18;
+      if (shortArtist) score += 0.12;
+      const titleEntities = this.index.titleIndex.get(entity.normalizedTitle)?.size ?? 0;
+      if (exactTitle && !fullArtist && !shortArtist && titleEntities === 1) {
+        score += 0.18;
+        reason = 'unique_exact_title';
+      }
+      if (!exactTitle && !fullArtist && !shortArtist && pinyinTitle) {
+        score = 0.68;
+        reason = 'pinyin_title_only';
+      }
+      if (score === 0 && Array.from(entity.normalizedTitle).length > 1) {
+        const sim = similarity(semantic, entity.normalizedTitle);
+        if (sim >= 0.7) {
+          score = Math.min(0.65, sim * 0.65);
+          reason = 'edit_distance_title_only';
+        }
+      }
+      if (normalized.wrapperStripped && score > 0) score += 0.02;
+      if (score > 0) score += historyBonus(entity);
+      if (score > 0) {
+        scored.push({ entity, score: Math.min(1, score), exactTitle: exactTitle || fullArtist || shortArtist, fullArtist, shortArtist, reason });
+      }
+    }
+
+    scored.sort((a, b) => b.score - a.score || a.entity.canonicalKey.localeCompare(b.entity.canonicalKey));
+    if (scored.length === 0 || scored[0].score <= 0) {
+      return { status: 'miss', reason: 'no_candidate', candidateCount: 0 };
+    }
+
+    const best = scored[0];
+    const secondScore = scored[1]?.score ?? 0;
+    const margin = best.score - secondScore;
+    const titleEntityCount = this.index.titleIndex.get(best.entity.normalizedTitle)?.size ?? 0;
+    const duplicateTitleWithoutArtist = titleEntityCount > 1 && !best.fullArtist && !best.shortArtist;
+    if (duplicateTitleWithoutArtist || (scored.length > 1 && margin < DIRECT_MARGIN_THRESHOLD)) {
+      return {
+        status: 'ambiguous',
+        canonicalKey: best.entity.canonicalKey,
+        score: best.score,
+        reason: duplicateTitleWithoutArtist ? 'duplicate_title' : 'candidate_margin_too_small',
+        candidateCount: scored.length,
+        margin,
+      };
+    }
+
+    const record = best.entity.representative;
+    const titleLength = Array.from(best.entity.normalizedTitle).length;
+    const hasArtistOrUniqueTitle = best.fullArtist || best.shortArtist || titleEntityCount === 1;
+    const playable = record.type === 'play_song' && !!record.songName && (
+      typeof record.songId === 'number' ||
+      (typeof record.playlistId === 'number' && typeof record.songIndex === 'number') ||
+      !!record.songName
+    );
+    const safe = best.score >= DIRECT_SCORE_THRESHOLD &&
+      margin >= DIRECT_MARGIN_THRESHOLD &&
+      best.exactTitle &&
+      hasArtistOrUniqueTitle &&
+      titleLength > 1 &&
+      record.successCount >= 1 &&
+      failureRate(best.entity) < 0.5 &&
+      playable;
+
+    if (!safe) {
+      return {
+        status: 'miss',
+        canonicalKey: best.entity.canonicalKey,
+        score: best.score,
+        reason: titleLength <= 1 ? 'single_character_title' : best.reason || 'below_safety_gate',
+        candidateCount: scored.length,
+        margin,
+      };
+    }
+
+    return {
+      status: 'entity_hit',
+      record,
+      canonicalKey: best.entity.canonicalKey,
+      score: best.score,
+      reason: best.reason,
+      candidateCount: scored.length,
+      margin,
+    };
+  }
+}

--- a/src/memory/memory_service.ts
+++ b/src/memory/memory_service.ts
@@ -1,10 +1,13 @@
 /// <reference types="@songloft/plugin-sdk" />
 
+import { MemoryEntityIndex, canonicalKeyForRecord } from './entity_index';
+import { MemoryResolver } from './memory_resolver';
 import { SongloftStorageMemoryAdapter } from './storage_adapter';
 import type {
   MemoryFindResult,
   MemoryRecord,
   MemoryRecordInput,
+  MemoryResolveResult,
   MemoryStorageAdapter,
   MemoryStoreSnapshot,
 } from './types';
@@ -22,12 +25,23 @@ function nowIso(): string {
   return new Date().toISOString();
 }
 
+function findById(records: Map<string, MemoryRecord>, id: string): MemoryRecord | null {
+  for (const record of records.values()) {
+    if (record.id === id) return record;
+  }
+  return null;
+}
+
 export class MemoryService {
-  private adapter: MemoryStorageAdapter;
+  private readonly adapter: MemoryStorageAdapter;
   private records: Map<string, MemoryRecord> = new Map();
+  private readonly entityIndex = new MemoryEntityIndex();
+  private readonly resolver = new MemoryResolver(this.entityIndex);
   private initialized = false;
+  private storageHealthy = false;
   private maxRecords: number;
   private initPromise: Promise<void> | null = null;
+  private writeQueue: Promise<void> = Promise.resolve();
 
   constructor(
     adapter: MemoryStorageAdapter = new SongloftStorageMemoryAdapter(),
@@ -40,7 +54,6 @@ export class MemoryService {
   async init(): Promise<void> {
     if (this.initialized) return;
     if (this.initPromise) return await this.initPromise;
-
     this.initPromise = this.initialize();
     try {
       await this.initPromise;
@@ -52,66 +65,88 @@ export class MemoryService {
   private async initialize(): Promise<void> {
     try {
       await this.load();
-      this.initialized = true;
+      this.initialized = this.storageHealthy;
     } catch (error) {
-      this.records.clear();
-      this.initialized = false;
-      songloft.log.warn('[MemoryService] init failed, memory disabled for this run: ' + String(error));
+      this.enterDegradedState('init', error);
     }
   }
 
   async load(): Promise<MemoryRecord[]> {
     try {
-      const snapshot = await this.adapter.load();
-      this.records = new Map(snapshot.records.map(record => [record.normalizedQuery, record]));
-      const evicted = this.enforceLimit();
-      if (evicted > 0) {
-        await this.save();
+      const result = await this.adapter.load();
+      if ((result.status === 'read_error' || result.status === 'format_error') || !result.snapshot) {
+        this.enterDegradedState(result.status, result.error || 'memory snapshot unavailable');
+        return [];
       }
+
+      this.storageHealthy = true;
+      if (result.invalidRecordCount) {
+        songloft.log.warn(`[VoiceMemoryV2] load ignored invalid records count=${result.invalidRecordCount}`);
+      }
+
+      const loaded = new Map(result.snapshot.records.map(record => [record.normalizedQuery, record]));
+      const candidate = new Map(loaded);
+      const evicted = this.enforceLimit(candidate);
+      if (evicted > 0) {
+        const saved = await this.persistCandidate(candidate);
+        this.records = saved ? candidate : loaded;
+      } else {
+        this.records = loaded;
+      }
+      this.rebuildIndex();
       return Array.from(this.records.values());
     } catch (error) {
-      this.records.clear();
-      songloft.log.warn('[MemoryService] load failed, using empty memory: ' + String(error));
+      this.enterDegradedState('load', error);
       return [];
     }
   }
 
   async save(): Promise<boolean> {
-    try {
-      this.enforceLimit();
-      const records = this.list();
-
-      const snapshot: MemoryStoreSnapshot = {
-        version: 1,
-        records,
-        updatedAt: nowIso(),
-      };
-      return await this.adapter.save(snapshot);
-    } catch (error) {
-      songloft.log.warn('[MemoryService] save failed, memory update skipped: ' + String(error));
-      return false;
-    }
+    return this.enqueueWrite('save', async () => this.commitCandidate(new Map(this.records)));
   }
 
   findByQuery(query: string): MemoryFindResult {
     try {
+      if (!this.initialized) return null;
       const normalizedQuery = this.normalizeQuery(query);
       if (!normalizedQuery) return null;
       return this.records.get(normalizedQuery) ?? null;
     } catch (error) {
-      songloft.log.warn('[MemoryService] findByQuery failed: ' + String(error));
+      songloft.log.warn('[VoiceMemoryV2] error fallback stage="find_exact" error="' + String(error) + '"');
       return null;
     }
   }
 
-  async recordSuccess(input: MemoryRecordInput): Promise<boolean> {
+  resolveEntity(query: string): MemoryResolveResult {
     try {
+      if (!this.initialized) return { status: 'miss', reason: 'memory_not_initialized', candidateCount: 0 };
+      return this.resolver.resolve(query);
+    } catch (error) {
+      songloft.log.warn('[VoiceMemoryV2] error fallback stage="resolve" error="' + String(error) + '"');
+      return { status: 'miss', reason: 'resolver_error', candidateCount: 0 };
+    }
+  }
+
+  async recordSuccess(input: MemoryRecordInput): Promise<boolean> {
+    return this.enqueueWrite('recordSuccess', async () => {
       const normalizedQuery = this.normalizeQuery(input.query);
       if (!normalizedQuery) return false;
 
-      const existing = this.records.get(normalizedQuery);
+      const candidate = new Map(this.records);
       const timestamp = nowIso();
-      const record: MemoryRecord = {
+      const matched = input.matchedRecordId ? findById(candidate, input.matchedRecordId) : null;
+      if (matched && matched.normalizedQuery !== normalizedQuery) {
+        candidate.set(matched.normalizedQuery, this.upgradeRecord({
+          ...matched,
+          hitCount: matched.hitCount + 1,
+          successCount: matched.successCount + 1,
+          updatedAt: timestamp,
+          lastUsedAt: timestamp,
+        }));
+      }
+
+      const existing = candidate.get(normalizedQuery);
+      const base: MemoryRecord = {
         id: existing?.id ?? `memory_${hashString(normalizedQuery)}`,
         query: input.query,
         normalizedQuery,
@@ -122,6 +157,7 @@ export class MemoryService {
         playlistId: input.playlistId,
         playlistName: input.playlistName,
         songIndex: input.songIndex,
+        canonicalKey: existing?.canonicalKey ?? matched?.canonicalKey,
         hitCount: (existing?.hitCount ?? 0) + 1,
         successCount: (existing?.successCount ?? 0) + 1,
         failureCount: existing?.failureCount ?? 0,
@@ -129,36 +165,29 @@ export class MemoryService {
         updatedAt: timestamp,
         lastUsedAt: timestamp,
       };
-
-      this.records.set(normalizedQuery, record);
-      return await this.save();
-    } catch (error) {
-      songloft.log.warn('[MemoryService] recordSuccess failed, memory update skipped: ' + String(error));
-      return false;
-    }
+      candidate.set(normalizedQuery, this.upgradeRecord(base));
+      this.enforceLimit(candidate);
+      return this.commitCandidate(candidate);
+    });
   }
 
-  async recordFailure(query: string): Promise<boolean> {
-    try {
+  async recordFailure(query: string, matchedRecordId?: string): Promise<boolean> {
+    return this.enqueueWrite('recordFailure', async () => {
       const normalizedQuery = this.normalizeQuery(query);
       if (!normalizedQuery) return false;
-
-      const existing = this.records.get(normalizedQuery);
+      const candidate = new Map(this.records);
+      const existing = candidate.get(normalizedQuery) ?? (matchedRecordId ? findById(candidate, matchedRecordId) : null);
       if (!existing) return false;
-
       const timestamp = nowIso();
-      this.records.set(normalizedQuery, {
+      candidate.set(existing.normalizedQuery, this.upgradeRecord({
         ...existing,
         hitCount: existing.hitCount + 1,
         failureCount: existing.failureCount + 1,
         updatedAt: timestamp,
         lastUsedAt: timestamp,
-      });
-      return await this.save();
-    } catch (error) {
-      songloft.log.warn('[MemoryService] recordFailure failed, memory update skipped: ' + String(error));
-      return false;
-    }
+      }));
+      return this.commitCandidate(candidate);
+    });
   }
 
   normalizeQuery(query: string): string {
@@ -176,9 +205,20 @@ export class MemoryService {
     return this.initialized;
   }
 
-  setMaxRecords(maxRecords: number): void {
-    this.maxRecords = normalizeMemoryMaxRecords(maxRecords);
-    this.enforceLimit();
+  isStorageHealthy(): boolean {
+    return this.storageHealthy;
+  }
+
+  async setMaxRecords(maxRecords: number): Promise<boolean> {
+    const normalized = normalizeMemoryMaxRecords(maxRecords);
+    if (normalized === this.maxRecords) return true;
+    return this.enqueueWrite('setMaxRecords', async () => {
+      this.maxRecords = normalized;
+      if (!this.initialized) return true;
+      const candidate = new Map(this.records);
+      const evicted = this.enforceLimit(candidate);
+      return evicted === 0 ? true : this.commitCandidate(candidate);
+    });
   }
 
   getMaxRecords(): number {
@@ -186,8 +226,7 @@ export class MemoryService {
   }
 
   list(): MemoryRecord[] {
-    return Array.from(this.records.values())
-      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+    return Array.from(this.records.values()).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
   }
 
   count(): number {
@@ -195,72 +234,113 @@ export class MemoryService {
   }
 
   findById(id: string): MemoryRecord | null {
-    for (const record of this.records.values()) {
-      if (record.id === id) return record;
-    }
-    return null;
+    return findById(this.records, id);
   }
 
   async trimToLimit(): Promise<boolean> {
-    try {
-      this.enforceLimit();
-      return await this.save();
-    } catch (error) {
-      songloft.log.warn('[MemoryService] trimToLimit failed: ' + String(error));
-      return false;
-    }
+    return this.enqueueWrite('trimToLimit', async () => {
+      const candidate = new Map(this.records);
+      const evicted = this.enforceLimit(candidate);
+      return evicted === 0 ? true : this.commitCandidate(candidate);
+    });
   }
 
   async deleteById(id: string): Promise<boolean> {
-    try {
-      const record = this.findById(id);
+    return this.enqueueWrite('deleteById', async () => {
+      const candidate = new Map(this.records);
+      const record = findById(candidate, id);
       if (!record) return false;
-
-      this.records.delete(record.normalizedQuery);
-      const saved = await this.save();
-      if (!saved) {
-        this.records.set(record.normalizedQuery, record);
-      }
-      return saved;
-    } catch (error) {
-      songloft.log.warn('[MemoryService] deleteById failed: ' + String(error));
-      return false;
-    }
+      candidate.delete(record.normalizedQuery);
+      return this.commitCandidate(candidate);
+    });
   }
 
   async clear(): Promise<boolean> {
+    return this.enqueueWrite('clear', async () => this.commitCandidate(new Map()));
+  }
+
+  getIndexStats(): { records: number; entities: number; aliases: number } {
+    return {
+      records: this.entityIndex.recordById.size,
+      entities: this.entityIndex.entities.size,
+      aliases: this.entityIndex.aliasIndex.size,
+    };
+  }
+
+  private upgradeRecord(record: MemoryRecord): MemoryRecord {
+    const canonicalKey = canonicalKeyForRecord(record);
+    if (!canonicalKey) return record;
+    return { ...record, recordVersion: 2, canonicalKey };
+  }
+
+  private async commitCandidate(candidate: Map<string, MemoryRecord>): Promise<boolean> {
+    if (!this.storageHealthy) {
+      songloft.log.warn('[VoiceMemoryV2] fallback stage="write" reason="storage_unavailable"');
+      return false;
+    }
+    this.enforceLimit(candidate);
+    const saved = await this.persistCandidate(candidate);
+    if (!saved) return false;
+    this.records = candidate;
+    this.rebuildIndex();
+    return true;
+  }
+
+  private async persistCandidate(candidate: Map<string, MemoryRecord>): Promise<boolean> {
+    const snapshot: MemoryStoreSnapshot = {
+      version: 1,
+      records: Array.from(candidate.values()).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
+      updatedAt: nowIso(),
+    };
     try {
-      const previous = new Map(this.records);
-      this.records.clear();
-      const saved = await this.save();
-      if (!saved) {
-        this.records = previous;
-      }
-      return saved;
+      return await this.adapter.save(snapshot);
     } catch (error) {
-      songloft.log.warn('[MemoryService] clear failed: ' + String(error));
+      songloft.log.warn('[VoiceMemoryV2] error fallback stage="save" error="' + String(error) + '"');
       return false;
     }
   }
 
-  private enforceLimit(): number {
-    const overflow = this.records.size - this.maxRecords;
+  private enqueueWrite(label: string, operation: () => Promise<boolean>): Promise<boolean> {
+    const task = this.writeQueue.catch(() => undefined).then(async () => {
+      try {
+        return await operation();
+      } catch (error) {
+        songloft.log.warn(`[VoiceMemoryV2] error fallback stage="${label}" error="${String(error)}"`);
+        return false;
+      }
+    });
+    this.writeQueue = task.then(() => undefined, error => {
+      songloft.log.warn(`[VoiceMemoryV2] error fallback stage="write_queue" error="${String(error)}"`);
+    });
+    return task;
+  }
+
+  private enforceLimit(records: Map<string, MemoryRecord>): number {
+    const overflow = records.size - this.maxRecords;
     if (overflow <= 0) return 0;
-
-    const oldest = Array.from(this.records.values())
-      .sort((a, b) => {
-        const lastUsedCompare = a.lastUsedAt.localeCompare(b.lastUsedAt);
-        if (lastUsedCompare !== 0) return lastUsedCompare;
-        const updatedCompare = a.updatedAt.localeCompare(b.updatedAt);
-        if (updatedCompare !== 0) return updatedCompare;
-        return a.createdAt.localeCompare(b.createdAt);
-      })
-      .slice(0, overflow);
-
-    for (const record of oldest) {
-      this.records.delete(record.normalizedQuery);
-    }
+    const oldest = Array.from(records.values()).sort((a, b) => {
+      const lastUsed = a.lastUsedAt.localeCompare(b.lastUsedAt);
+      if (lastUsed !== 0) return lastUsed;
+      const updated = a.updatedAt.localeCompare(b.updatedAt);
+      if (updated !== 0) return updated;
+      return a.createdAt.localeCompare(b.createdAt);
+    }).slice(0, overflow);
+    for (const record of oldest) records.delete(record.normalizedQuery);
     songloft.log.info(`[MemoryService] evicted ${oldest.length} old record(s), limit=${this.maxRecords}`);
     return oldest.length;
+  }
+
+  private rebuildIndex(): void {
+    this.entityIndex.rebuild(this.records.values());
+    const stats = this.getIndexStats();
+    songloft.log.info(`[VoiceMemoryV2] index_rebuilt records=${stats.records} entities=${stats.entities} aliases=${stats.aliases}`);
+  }
+
+  private enterDegradedState(stage: string, error: unknown): void {
+    this.records.clear();
+    this.entityIndex.clear();
+    this.initialized = false;
+    this.storageHealthy = false;
+    songloft.log.warn(`[VoiceMemoryV2] error fallback stage="${stage}" error="${String(error)}"`);
   }
 }

--- a/src/memory/query_normalizer.ts
+++ b/src/memory/query_normalizer.ts
@@ -1,0 +1,92 @@
+import { toPinyin } from '../indexing/segmenter';
+
+const PREFIXES = [
+  '帮我播放一下',
+  '帮我放一下',
+  '给我播放一下',
+  '给我播放',
+  '我想听',
+  '我要听',
+  '来一首',
+  '放一首',
+  '听一下',
+  '播放一下',
+  '播放',
+  '来首',
+  '放一下',
+  '放',
+].sort((a, b) => Array.from(b).length - Array.from(a).length);
+
+const SUFFIXES = ['可以吗', '好吗', '谢谢', '一下吧']
+  .sort((a, b) => Array.from(b).length - Array.from(a).length);
+
+function foldFullWidth(value: string): string {
+  return Array.from(value || '').map(ch => {
+    const code = ch.charCodeAt(0);
+    if (code === 0x3000) return ' ';
+    if (code >= 0xff01 && code <= 0xff5e) {
+      return String.fromCharCode(code - 0xfee0);
+    }
+    return ch;
+  }).join('');
+}
+
+/** Stable text key for known song and artist entities. Keeps meaningful Chinese characters such as "的". */
+export function normalizeEntityText(value: string): string {
+  return foldFullWidth(value)
+    .toLowerCase()
+    .replace(/[\s　《》【】「」『』〔〕〈〉（）()\[\]{}，,。.、·!！?？~～—\-_:：;；'"`“”‘’…]/g, '')
+    .trim();
+}
+
+export interface NormalizedMemoryQuery {
+  originalQuery: string;
+  semanticText: string;
+  wrapperStripped: boolean;
+  pinyin: string;
+}
+
+/** Removes only anchored, explicit playback wrappers. It never globally removes words or the character "的". */
+export function normalizeMemoryQuery(query: string): NormalizedMemoryQuery {
+  const originalQuery = query || '';
+  let semanticText = normalizeEntityText(originalQuery);
+  let wrapperStripped = false;
+
+  for (const prefix of PREFIXES) {
+    const normalizedPrefix = normalizeEntityText(prefix);
+    if (semanticText.startsWith(normalizedPrefix) && semanticText.length > normalizedPrefix.length) {
+      semanticText = semanticText.slice(normalizedPrefix.length);
+      wrapperStripped = true;
+      break;
+    }
+  }
+
+  for (const suffix of SUFFIXES) {
+    const normalizedSuffix = normalizeEntityText(suffix);
+    if (semanticText.endsWith(normalizedSuffix) && semanticText.length > normalizedSuffix.length) {
+      semanticText = semanticText.slice(0, -normalizedSuffix.length);
+      wrapperStripped = true;
+      break;
+    }
+  }
+
+  return {
+    originalQuery,
+    semanticText,
+    wrapperStripped,
+    pinyin: compactPinyin(semanticText),
+  };
+}
+
+export function compactPinyin(value: string): string {
+  return toPinyin(value).replace(/\s+/g, '').toLowerCase();
+}
+
+export function isChineseName(value: string): boolean {
+  const chars = Array.from(value);
+  return chars.length >= 3 && chars.every(ch => /[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]/.test(ch));
+}
+
+export function readableKeyPart(value: string): string {
+  return encodeURIComponent(value).replace(/%/g, '~');
+}

--- a/src/memory/self_test.ts
+++ b/src/memory/self_test.ts
@@ -1,0 +1,223 @@
+import { MemoryEntityIndex } from './entity_index';
+import { MemoryResolver } from './memory_resolver';
+import { MemoryService } from './memory_service';
+import { normalizeMemoryQuery } from './query_normalizer';
+import type { MemoryLoadResult, MemoryRecord, MemoryStorageAdapter, MemoryStoreSnapshot } from './types';
+
+export interface MemoryV2SelfTestCheck {
+  name: string;
+  ok: boolean;
+  message?: string;
+}
+
+export interface MemoryV2SelfTestResult {
+  ok: boolean;
+  checks: MemoryV2SelfTestCheck[];
+  performance: Record<string, number>;
+  runtimeChecks: string[];
+}
+
+function timestamp(offset = 0): string {
+  return new Date(Date.UTC(2026, 0, 1, 0, 0, offset)).toISOString();
+}
+
+function record(
+  id: string,
+  query: string,
+  songName?: string,
+  artist?: string,
+  songId?: number,
+): MemoryRecord {
+  return {
+    id,
+    query,
+    normalizedQuery: query.toLowerCase().replace(/\s+/g, ''),
+    type: 'play_song',
+    songId,
+    songName,
+    artist,
+    playlistId: songName ? 1 : undefined,
+    playlistName: songName ? 'self-test' : undefined,
+    songIndex: songName ? 0 : undefined,
+    hitCount: 1,
+    successCount: 1,
+    failureCount: 0,
+    createdAt: timestamp(),
+    updatedAt: timestamp(),
+    lastUsedAt: timestamp(),
+  };
+}
+
+function snapshot(records: MemoryRecord[]): MemoryStoreSnapshot {
+  return { version: 1, records, updatedAt: timestamp() };
+}
+
+class InMemoryAdapter implements MemoryStorageAdapter {
+  current: MemoryStoreSnapshot;
+  loadStatus: MemoryLoadResult['status'] = 'ok';
+  failSave = false;
+  throwSaveOnce = false;
+  saveCount = 0;
+
+  constructor(records: MemoryRecord[] = []) {
+    this.current = snapshot(records);
+  }
+
+  async load(): Promise<MemoryLoadResult> {
+    if (this.loadStatus === 'read_error' || this.loadStatus === 'format_error') {
+      return { status: this.loadStatus, error: 'self-test load failure' };
+    }
+    return { status: this.loadStatus, snapshot: JSON.parse(JSON.stringify(this.current)) as MemoryStoreSnapshot };
+  }
+
+  async save(value: MemoryStoreSnapshot): Promise<boolean> {
+    this.saveCount++;
+    if (this.throwSaveOnce) {
+      this.throwSaveOnce = false;
+      throw new Error('self-test rejected save');
+    }
+    if (this.failSave) return false;
+    this.current = JSON.parse(JSON.stringify(value)) as MemoryStoreSnapshot;
+    return true;
+  }
+}
+
+function resolve(records: MemoryRecord[], query: string) {
+  const index = new MemoryEntityIndex();
+  index.rebuild(records);
+  return { result: new MemoryResolver(index).resolve(query), index };
+}
+
+export async function runMemoryV2SelfTest(): Promise<MemoryV2SelfTestResult> {
+  const checks: MemoryV2SelfTestCheck[] = [];
+  const performance: Record<string, number> = {};
+  const check = (name: string, ok: boolean, message = ''): void => {
+    checks.push({ name, ok, ...(message ? { message } : {}) });
+  };
+
+  const sunny = record('sunny-1', '来首周杰伦的晴天', '晴天', '周杰伦', 101);
+  const v1Adapter = new InMemoryAdapter([sunny]);
+  const v1Service = new MemoryService(v1Adapter);
+  await v1Service.init();
+  check('v1_exact_unchanged', v1Service.findByQuery('来首周杰伦的晴天')?.id === sunny.id);
+  check('unique_title_hit', v1Service.resolveEntity('放晴天').status === 'entity_hit');
+  check('unique_short_artist_hit', v1Service.resolveEntity('来首杰伦的晴天').status === 'entity_hit');
+  check('full_artist_title_hit', v1Service.resolveEntity('我想听周杰伦晴天').status === 'entity_hit');
+
+  const sameSongRecords = [
+    sunny,
+    record('sunny-2', '放晴天', '晴天', '周杰伦', 101),
+    record('sunny-3', '我想听周杰伦晴天', '晴天', '周杰伦', 101),
+  ];
+  check('same_song_queries_one_entity', resolve(sameSongRecords, '放晴天').index.entities.size === 1);
+
+  const duplicated = [
+    record('later-1', '播放刘若英后来', '后来', '刘若英', 201),
+    record('later-2', '播放其他歌手后来', '后来', '其他歌手', 202),
+  ];
+  check('duplicate_title_ambiguous', resolve(duplicated, '播放后来').result.status === 'ambiguous');
+  check('duplicate_title_full_artist_hit', resolve(duplicated, '播放刘若英的后来').result.status === 'entity_hit');
+
+  const shortCollision = [
+    record('short-1', '播放张杰伦甲歌', '甲歌', '张杰伦', 301),
+    record('short-2', '播放周杰伦乙歌', '乙歌', '周杰伦', 302),
+  ];
+  check('shared_short_artist_disabled', resolve(shortCollision, '播放杰伦的乙歌').result.status !== 'entity_hit');
+  check('single_character_title_blocked', resolve([record('one', '播放光', '光', '陈粒', 401)], '播放光').result.status !== 'entity_hit');
+  check('homophone_only_blocked', resolve([sunny], '播放青天').result.status !== 'entity_hit');
+
+  const preservedDe = normalizeMemoryQuery('播放你不知道的事').semanticText;
+  const preservedMusic = normalizeMemoryQuery('播放音乐之声').semanticText;
+  check('title_with_de_preserved', preservedDe === '你不知道的事');
+  check('title_with_music_preserved', preservedMusic === '音乐之声');
+  check('fixed_control_not_memory_candidate', resolve([sunny], '暂停播放').result.status !== 'entity_hit');
+
+  const legacy = record('legacy', '旧口令', undefined, undefined, undefined);
+  const legacyService = new MemoryService(new InMemoryAdapter([legacy]));
+  await legacyService.init();
+  check('legacy_v1_loads', legacyService.findByQuery('旧口令')?.id === legacy.id);
+  check('legacy_without_song_not_v2', legacyService.resolveEntity('旧口令').status !== 'entity_hit');
+
+  const deleteService = new MemoryService(new InMemoryAdapter([sunny]));
+  await deleteService.init();
+  await deleteService.deleteById(sunny.id);
+  check('delete_removes_alias', deleteService.resolveEntity('放晴天').status !== 'entity_hit');
+
+  const clearService = new MemoryService(new InMemoryAdapter([sunny]));
+  await clearService.init();
+  await clearService.clear();
+  check('clear_removes_indexes', clearService.getIndexStats().entities === 0 && clearService.getIndexStats().aliases === 0);
+
+  const evictionRecords = Array.from({ length: 11 }, (_, i) => record(`evict-${i}`, `播放测试歌${i}`, `测试歌${i}`, '测试歌手', 500 + i));
+  const evictionService = new MemoryService(new InMemoryAdapter(evictionRecords), 10);
+  await evictionService.init();
+  check('eviction_rebuilds_indexes', evictionService.count() === 10 && evictionService.getIndexStats().records === 10);
+
+  const failedAdapter = new InMemoryAdapter([sunny]);
+  const failedService = new MemoryService(failedAdapter);
+  await failedService.init();
+  const beforeFailure = JSON.stringify(failedService.list());
+  failedAdapter.failSave = true;
+  await failedService.recordSuccess({ query: '新的晴天口令', type: 'play_song', songName: '晴天', artist: '周杰伦', songId: 101 });
+  check('save_failure_keeps_state', JSON.stringify(failedService.list()) === beforeFailure && failedService.resolveEntity('新的晴天口令').status !== 'entity_hit');
+
+  const readFailedAdapter = new InMemoryAdapter([sunny]);
+  readFailedAdapter.loadStatus = 'read_error';
+  const readFailedService = new MemoryService(readFailedAdapter);
+  await readFailedService.init();
+  const writeAfterReadFailure = await readFailedService.recordSuccess({ query: '不应写入', type: 'play_song', songName: '晴天', artist: '周杰伦', songId: 101 });
+  check('read_failure_never_overwrites', !readFailedService.isInitialized() && !writeAfterReadFailure && readFailedAdapter.saveCount === 0);
+
+  const recoveringAdapter = new InMemoryAdapter();
+  const recoveringService = new MemoryService(recoveringAdapter);
+  await recoveringService.init();
+  recoveringAdapter.throwSaveOnce = true;
+  const rejectedWrite = await recoveringService.recordSuccess({ query: '失败写入', type: 'play_song', songName: '失败歌曲', artist: '测试歌手', songId: 601 });
+  const recoveredWrite = await recoveringService.recordSuccess({ query: '恢复写入', type: 'play_song', songName: '恢复歌曲', artist: '测试歌手', songId: 602 });
+  check('write_queue_recovers_after_rejection', !rejectedWrite && recoveredWrite && recoveringService.findByQuery('恢复写入') !== null);
+
+  const formatFailedAdapter = new InMemoryAdapter([sunny]);
+  formatFailedAdapter.loadStatus = 'format_error';
+  const formatFailedService = new MemoryService(formatFailedAdapter);
+  await formatFailedService.init();
+  const formatWrite = await formatFailedService.recordSuccess({ query: '格式错误后写入', type: 'play_song', songName: '晴天', artist: '周杰伦', songId: 101 });
+  check('format_failure_never_overwrites', !formatFailedService.isInitialized() && !formatWrite && formatFailedAdapter.saveCount === 0);
+
+  const concurrentAdapter = new InMemoryAdapter();
+  const concurrentService = new MemoryService(concurrentAdapter, 100);
+  await concurrentService.init();
+  await Promise.all(Array.from({ length: 20 }, (_, i) => concurrentService.recordSuccess({
+    query: `并发口令${i}`,
+    type: 'play_song',
+    songName: `并发歌曲${i}`,
+    artist: '并发歌手',
+    songId: 700 + i,
+  })));
+  check('concurrent_writes_no_loss', concurrentService.count() === 20 && concurrentService.getIndexStats().records === 20);
+
+  const deleteId = concurrentService.list()[0].id;
+  await Promise.all([
+    concurrentService.deleteById(deleteId),
+    concurrentService.recordSuccess({ query: '并发新增', type: 'play_song', songName: '并发新增', artist: '并发歌手', songId: 999 }),
+    concurrentService.setMaxRecords(10),
+  ]);
+  check('mixed_concurrency_consistent', concurrentService.count() <= 10 && concurrentService.getIndexStats().records === concurrentService.count());
+
+  for (const size of [10, 100, 1000]) {
+    const records = Array.from({ length: size }, (_, i) => record(`perf-${size}-${i}`, `播放性能歌曲${i}`, `性能歌曲${i}`, '性能歌手', 10000 + i));
+    const start = Date.now();
+    const index = new MemoryEntityIndex();
+    index.rebuild(records);
+    new MemoryResolver(index).resolve(`播放性能歌曲${size - 1}`);
+    performance[`records_${size}_ms`] = Date.now() - start;
+  }
+  check('bounded_performance', Object.values(performance).every(ms => ms < 2000), JSON.stringify(performance));
+
+  const runtimeChecks = [
+    'fixed control commands are executed before memory in VoiceEngine.handleMessage',
+    'voice_memory_enabled=false skips lookup and writes',
+    'memory playback failure falls through to rules and AI',
+    'resolver or memory exceptions fall through to rules and AI',
+  ];
+  return { ok: checks.every(item => item.ok), checks, performance, runtimeChecks };
+}

--- a/src/memory/storage_adapter.ts
+++ b/src/memory/storage_adapter.ts
@@ -1,6 +1,11 @@
 /// <reference types="@songloft/plugin-sdk" />
 
-import type { MemoryRecord, MemoryStoreSnapshot, MemoryStorageAdapter as MemoryStorageAdapterContract } from './types';
+import type {
+  MemoryLoadResult,
+  MemoryRecord,
+  MemoryStoreSnapshot,
+  MemoryStorageAdapter as MemoryStorageAdapterContract,
+} from './types';
 
 const MEMORY_STORAGE_KEY = 'memory:v1:records';
 
@@ -27,38 +32,50 @@ function isMemoryRecord(value: unknown): value is MemoryRecord {
     typeof value.failureCount === 'number' &&
     typeof value.createdAt === 'string' &&
     typeof value.updatedAt === 'string' &&
-    typeof value.lastUsedAt === 'string'
+    typeof value.lastUsedAt === 'string' &&
+    (value.query === undefined || typeof value.query === 'string') &&
+    (value.recordVersion === undefined || value.recordVersion === 2) &&
+    (value.canonicalKey === undefined || typeof value.canonicalKey === 'string')
   );
 }
 
-function parseSnapshot(raw: unknown): MemoryStoreSnapshot {
+function parseSnapshot(raw: unknown): MemoryLoadResult {
+  let parsed: unknown;
   try {
-    const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
-    if (!isObject(parsed) || parsed.version !== 1 || !Array.isArray(parsed.records)) {
-      return emptySnapshot();
-    }
-
-    return {
-      version: 1,
-      records: parsed.records.filter(isMemoryRecord),
-      updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : new Date().toISOString(),
-    };
-  } catch {
-    return emptySnapshot();
+    parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+  } catch (error) {
+    return { status: 'format_error', error: String(error) };
   }
+
+  if (!isObject(parsed) || parsed.version !== 1 || !Array.isArray(parsed.records)) {
+    return { status: 'format_error', error: 'invalid memory snapshot envelope' };
+  }
+
+  const records = parsed.records.filter(isMemoryRecord);
+  if (parsed.records.length > 0 && records.length === 0) {
+    return { status: 'format_error', error: 'memory snapshot contains no valid records' };
+  }
+  return {
+    status: 'ok',
+    snapshot: {
+      version: 1,
+      records,
+      updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : new Date().toISOString(),
+    },
+    invalidRecordCount: parsed.records.length - records.length,
+  };
 }
 
 export class SongloftStorageMemoryAdapter implements MemoryStorageAdapterContract {
-  async load(): Promise<MemoryStoreSnapshot> {
+  async load(): Promise<MemoryLoadResult> {
     try {
       const raw = await songloft.storage.get(MEMORY_STORAGE_KEY);
       if (raw === null || raw === undefined || raw === '') {
-        return emptySnapshot();
+        return { status: 'missing', snapshot: emptySnapshot() };
       }
       return parseSnapshot(raw);
     } catch (error) {
-      songloft.log.warn('[MemoryStorage] load failed, using empty memory: ' + String(error));
-      return emptySnapshot();
+      return { status: 'read_error', error: String(error) };
     }
   }
 

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -27,6 +27,8 @@ export interface MemoryRecord {
   createdAt: string;
   updatedAt: string;
   lastUsedAt: string;
+  recordVersion?: 2;
+  canonicalKey?: string;
 }
 
 export interface MemoryRecordInput {
@@ -38,6 +40,7 @@ export interface MemoryRecordInput {
   playlistId?: number;
   playlistName?: string;
   songIndex?: number;
+  matchedRecordId?: string;
 }
 
 export interface MemoryStoreSnapshot {
@@ -48,7 +51,28 @@ export interface MemoryStoreSnapshot {
 
 export type MemoryFindResult = MemoryRecord | null;
 
+export type MemoryLoadStatus = 'ok' | 'missing' | 'read_error' | 'format_error';
+
+export interface MemoryLoadResult {
+  status: MemoryLoadStatus;
+  snapshot?: MemoryStoreSnapshot;
+  error?: string;
+  invalidRecordCount?: number;
+}
+
+export type MemoryResolveStatus = 'exact' | 'entity_hit' | 'ambiguous' | 'miss';
+
+export interface MemoryResolveResult {
+  status: MemoryResolveStatus;
+  record?: MemoryRecord;
+  canonicalKey?: string;
+  score?: number;
+  reason?: string;
+  candidateCount?: number;
+  margin?: number;
+}
+
 export interface MemoryStorageAdapter {
-  load(): Promise<MemoryStoreSnapshot>;
+  load(): Promise<MemoryLoadResult>;
   save(snapshot: MemoryStoreSnapshot): Promise<boolean>;
 }

--- a/src/voicecmd/engine.ts
+++ b/src/voicecmd/engine.ts
@@ -246,21 +246,22 @@ export class VoiceEngine {
       return;
     }
 
-    const pluginConfig = await this.configManager.getConfig();
-    const memoryEnabled = pluginConfig.voice_memory_enabled;
-    this.memoryService.setMaxRecords(pluginConfig.voice_memory_max_records);
-
-    if (memoryEnabled) {
-      try {
+    let memoryEnabled = false;
+    try {
+      const pluginConfig = await this.configManager.getConfig();
+      memoryEnabled = pluginConfig.voice_memory_enabled;
+      await this.memoryService.setMaxRecords(pluginConfig.voice_memory_max_records);
+      if (memoryEnabled) {
         const memoryHandled = await this.tryHandleMemory(query, accountId, msg.device_id);
         if (memoryHandled) {
           return;
         }
-      } catch (error) {
-        songloft.log.warn('[VoiceMemory] error fallback: ' + String(error));
+      } else {
+        songloft.log.info('[VoiceMemoryV2] miss reason="disabled"');
       }
-    } else {
-      songloft.log.info('[VoiceMemory] disabled');
+    } catch (error) {
+      memoryEnabled = false;
+      songloft.log.warn('[VoiceMemoryV2] error fallback stage="config_or_memory" error="' + String(error) + '"');
     }
 
     // 歌曲/歌单规则匹配
@@ -324,35 +325,58 @@ export class VoiceEngine {
     try {
       await this.ensureMemoryInitialized();
       if (!this.memoryInitialized) {
-        songloft.log.info(`[VoiceMemory] miss query="${query}" reason="memory service not initialized"`);
+        songloft.log.info(`[VoiceMemoryV2] miss query="${query}" reason="memory_not_initialized"`);
         return false;
       }
 
-      const record = this.memoryService.findByQuery(query);
-      if (!record) {
-        songloft.log.info(`[VoiceMemory] miss query="${query}"`);
-        return false;
+      let record = this.memoryService.findByQuery(query);
+      let matchMode: 'exact' | 'entity_hit' = 'exact';
+      let canonicalKey: string | undefined;
+      let score: number | undefined;
+      let reason = 'v1_normalized_query';
+
+      if (record) {
+        songloft.log.info(`[VoiceMemoryV2] exact_hit query="${query}" id="${record.id}"`);
+      } else {
+        const resolved = this.memoryService.resolveEntity(query);
+        if (resolved.status === 'ambiguous') {
+          songloft.log.info(`[VoiceMemoryV2] ambiguous query="${query}" candidates=${resolved.candidateCount ?? 0} reason="${resolved.reason || 'ambiguous'}"`);
+          return false;
+        }
+        if (resolved.status !== 'entity_hit' || !resolved.record) {
+          songloft.log.info(`[VoiceMemoryV2] miss query="${query}" reason="${resolved.reason || 'no_candidate'}" score=${(resolved.score ?? 0).toFixed(2)}`);
+          return false;
+        }
+        record = resolved.record;
+        matchMode = 'entity_hit';
+        canonicalKey = resolved.canonicalKey;
+        score = resolved.score;
+        reason = resolved.reason || 'entity_match';
       }
 
       if (record.type !== 'play_song') {
-        songloft.log.info(`[VoiceMemory] miss query="${query}" reason="unsupported type=${record.type}"`);
+        songloft.log.info(`[VoiceMemoryV2] miss query="${query}" reason="unsupported_type_${record.type}"`);
         return false;
       }
 
       const playedSong = await this.executeMemorySong(record, query, accountId, deviceId);
       if (!playedSong) {
-        void this.memoryService.recordFailure(query).catch(error => {
-          songloft.log.warn('[VoiceMemory] error fallback: record failure failed: ' + String(error));
+        void this.memoryService.recordFailure(query, record.id).catch(error => {
+          songloft.log.warn('[VoiceMemoryV2] error fallback stage="record_failure" error="' + String(error) + '"');
         });
-        songloft.log.warn(`[VoiceMemory] error fallback: hit could not be played id=${record.id}`);
+        songloft.log.warn(`[VoiceMemoryV2] fallback query="${query}" reason="play_failed" id="${record.id}"`);
         return false;
       }
 
-      songloft.log.info(`[VoiceMemory] hit query="${query}" song="${playedSong.songName}" artist="${playedSong.artist}"`);
-      this.queueMemorySuccess(query, playedSong);
+      if (matchMode === 'entity_hit') {
+        songloft.log.info(`[VoiceMemoryV2] entity_hit query="${query}" song="${playedSong.songName}" artist="${playedSong.artist}" score=${(score ?? 0).toFixed(2)} reason="${reason}" canonicalKey="${canonicalKey || ''}"`);
+        this.queueMemorySuccess(query, playedSong, record.id);
+      } else {
+        this.queueMemorySuccess(query, playedSong);
+      }
       return true;
     } catch (error) {
-      songloft.log.warn('[VoiceMemory] error fallback: ' + String(error));
+      songloft.log.warn('[VoiceMemoryV2] error fallback stage="play" error="' + String(error) + '"');
       return false;
     }
   }
@@ -410,8 +434,8 @@ export class VoiceEngine {
     return null;
   }
 
-  private queueMemorySuccess(query: string, song: PlayedSong): void {
-    songloft.log.info(`[VoiceMemory] recordSuccess queued query="${query}" song="${song.songName}"`);
+  private queueMemorySuccess(query: string, song: PlayedSong, matchedRecordId?: string): void {
+    songloft.log.info(`[VoiceMemoryV2] lazy_migrate queued query="${query}" song="${song.songName}"`);
     void this.memoryService.recordSuccess({
       query,
       type: 'play_song',
@@ -421,14 +445,15 @@ export class VoiceEngine {
       playlistId: song.playlistId,
       playlistName: song.playlistName,
       songIndex: song.songIndex,
+      matchedRecordId,
     }).then(saved => {
       if (saved) {
-        songloft.log.info(`[VoiceMemory] recordSuccess done query="${query}"`);
+        songloft.log.info(`[VoiceMemoryV2] lazy_migrate done query="${query}"`);
       } else {
-        songloft.log.warn(`[VoiceMemory] recordSuccess failed query="${query}" reason="save returned false"`);
+        songloft.log.warn(`[VoiceMemoryV2] lazy_migrate failed query="${query}" reason="save_returned_false"`);
       }
     }).catch(error => {
-      songloft.log.warn(`[VoiceMemory] recordSuccess failed query="${query}" error=${String(error)}`);
+      songloft.log.warn(`[VoiceMemoryV2] error fallback stage="record_success" error="${String(error)}"`);
     });
   }
 


### PR DESCRIPTION
## 功能概述

本 PR 基于已有 Voice Memory 功能，新增轻量级 Voice Memory V2 实体解析机制，让语音记忆从简单的“历史口令匹配”升级为“理解用户意图并关联歌曲实体”。

V2 的目标是在不增加外部服务、向量数据库、复杂 AI 模型以及额外运行依赖的情况下，通过本地轻量索引和规则解析，让系统能够理解用户不同表达方式指向同一首歌曲，提高语音响应速度和稳定性，同时减少不必要的 AI 调用。

用户第一次通过 AI 或规则流程成功播放歌曲后，系统会保存歌曲实体信息。后续用户使用相似表达时，可以优先通过 Voice Memory V2 本地解析直接匹配歌曲，只有无法高置信匹配时才继续进入原有规则匹配和 AI fallback 流程。

## 主要改动

- 新增 Voice Memory V2 查询标准化模块，对用户自然语言口令进行轻量处理；
- 新增歌曲实体索引，根据歌曲 ID、标题、歌手等信息建立稳定关联；
- 新增 Memory Resolver，实现不同表达方式映射到同一歌曲实体；
- 新增 V2 自测模块，用于验证匹配、安全边界和存储一致性；
- 保留 V1 精确匹配逻辑，保证已有用户记忆数据兼容；
- 增加 storage 读取保护、写入队列和索引重建机制，提高数据安全性；
- 优化异常处理，任何 Voice Memory V2 异常都会自动回退原有规则和 AI 流程。

## 匹配能力提升

V1 主要依赖完全相同的语音口令，例如用户第一次保存“晴天”，后续再次说“晴天”可以命中。

V2 增加实体解析能力，可以理解不同表达指向同一歌曲，例如：

- “晴天” → 匹配《晴天》
- “我想听晴天” → 匹配《晴天》
- “来首杰伦的晴天” → 匹配周杰伦《晴天》
- “放晴天” → 匹配已学习歌曲

同时保持严格安全策略：

- 不会因为单独输入歌手名称直接播放，例如“播放杰伦”；
- 不会因为拼音相似直接播放；
- 不会因为同音字直接播放；
- 不会在候选歌曲存在歧义时强制匹配；
- 低置信度结果继续交给原有 AI 分析流程。

## 安全和兼容性

V2 采用保守匹配策略，只有在歌曲实体唯一、置信度达到要求、存在可靠播放信息时才允许直接播放。

现有 V1 数据继续兼容，不需要用户重新建立记忆。旧记录通过懒迁移方式逐步升级，避免一次性修改大量历史数据。

同时增加：

- storage 读取异常保护；
- 写入失败保护；
- 并发写入队列；
- 索引自动重建；
- resolver 异常 fallback。

确保 Voice Memory V2 出现任何异常时，不影响原有播放功能。

## 实际测试

已在真实 NAS + MIoT 插件 + 小米智能音箱环境完成测试。

验证结果：

- “晴天” → VoiceMemoryV2 exact_hit → 成功播放；
- “来首杰伦的晴天” → VoiceMemoryV2 entity_hit → 成功播放；
- “播放杰伦” → VoiceMemoryV2 未匹配 → 正常进入 AI fallback，没有误播放已记忆歌曲；
- “暂停播放” → 固定控制命令优先匹配，没有被 Voice Memory 拦截；
- “青天” → 未触发《晴天》的 Voice Memory 实体匹配，避免同音误播放。

## 构建验证

已完成：

- npm run build ✅
- git diff --check ✅
- TypeScript 类型检查 ✅

未执行：

- npm run validate

## 总结

Voice Memory V2 将原有“记录用户说过的话”的能力升级为“理解用户想听什么”。

通过轻量级实体解析、本地索引和安全匹配策略，实现：

用户第一次：
AI 理解 → 播放成功 → 保存歌曲实体

用户以后：
自然表达 → 本地 Memory Resolver → 快速匹配 → 直接播放

同时保持低资源占用，适配 NAS / ARM 环境，并保证原有 AI fallback 和播放逻辑稳定运行。