### PR TITLE
feat: 新增 Voice Memory V3 可视化语音记忆管理功能

### DIFF
--- a/docs/memory-v3-design.md
+++ b/docs/memory-v3-design.md
@@ -1,0 +1,62 @@
+# Voice Memory V3 设计与实现
+
+## 定位
+
+Voice Memory V3 在 V1 精确口令和 V2 实体解析之上增加可视化管理，不替代实时 resolver。固定控制命令仍然绝对优先，语音顺序保持为：固定控制命令、V1 exact、V2 entity、歌曲/歌单规则、AI fallback。
+
+V3 只管理单曲记忆，不接管歌单匹配，不修改 AI API、提示词或账号认证。
+
+## 数据兼容
+
+- 继续使用 `memory:v1:records` 和 snapshot version `1`。
+- 旧 `MemoryRecord` 字段不变；V3 字段全部可选。
+- `manualAlias` 和 `aliasSource` 标识手动用户说法。
+- `memoryHitCount`、`savedAiCalls` 和 `lastHitReason` 保存轻量累计统计。
+- 缺少新字段的 V1/V2 记录可以直接加载；展示统计时使用已有 `hitCount` 做保守近似。
+- 缺少 `canonicalKey` 的旧记录由 V2 索引在内存中聚合，后续正常命中或写入时懒迁移。
+
+## 实体聚合与别名
+
+管理 API 按现有 `MemoryEntityIndex` 的 canonical entity 聚合记录。同一歌曲的多个 query 只展示为一个实体，原始 query 在实体详情中按需展开。
+
+缺少歌曲元数据、无法进入实体索引的旧记录不会被修改或强制生成 canonicalKey。它们继续支持 V1 exact，并在独立、默认折叠的“未归类记忆”区域中展示和删除，不会混入正常歌曲实体列表。统计中的用户说法数量仍包含这些记录。
+
+手动别名作为普通 `MemoryRecord` 写入原快照，因此 V1 exact 可以直接命中，同时删除、清空、数量淘汰和索引重建继续复用既有机制。别名要求 2 到 30 个字符，拒绝空值、重复值、宽泛词和固定控制词。
+
+## 统计写入
+
+首次学习新口令和 V2 新实体说法仍走现有串行写队列。已迁移的 V1 exact 命中只在内存中累计，并在 5 秒后合并写入一次完整快照。统计写入失败会保留待写增量，不影响播放。
+
+`savedAiCalls` 表示本地 V1/V2 成功命中次数，是节省 AI 调用的轻量近似值。系统不保存完整命中历史。
+
+## 歧义记录
+
+V2 resolver 已明确返回 `ambiguous` 时，VoiceEngine 异步记录 query、原因、候选摘要、出现次数和最后时间，然后继续原规则及 AI fallback。
+
+歧义数据使用独立的 `memory:v3:ambiguous` storage key，最多保留最近 20 条并防抖保存。读取或写入失败不会改变语音处理结果，也不会覆盖 `memory:v1:records`。
+
+## 管理 API
+
+- `GET /memory/stats`：统计摘要。
+- `GET /memory/entities`：聚合实体和用户说法。
+- `POST /memory/aliases`：添加手动别名，body 为 `canonicalKey`、`alias`。
+- `DELETE /memory/aliases`：删除单条用户说法，query 为 `canonicalKey`、`recordId`。
+- `DELETE /memory/entity`：删除整组歌曲记忆，query 为 `canonicalKey`。
+- `GET /memory/ambiguous`：最近歧义记录。
+
+原有 `GET /memory`、`DELETE /memory`、`DELETE /memory/all` 和 `/memory/self-test` 保留。
+
+## 设置页
+
+语音记忆仍位于 PR #47 的 `data-category="voice"` 卡片内。管理区默认折叠，仅加载统计摘要；展开后才加载实体和歧义。每个歌曲实体的用户说法再次独立折叠。实体列表桌面端最大高度 480px，移动端最大高度 50vh。
+
+Voice Memory 开关不依赖 AI 开关。AI 关闭后，已有记忆仍可命中；复杂新口令的首次学习能力会受限。
+
+## 资源限制与已知限制
+
+- 默认 100 条，允许 10 到 500 条。
+- 不新增依赖、数据库、模型、向量索引或外部服务。
+- UI 聚合只在管理请求时计算，不进入语音热路径。
+- 歧义候选最多保存 5 个摘要，歧义记录最多 20 条。
+- 插件在防抖窗口内被强制终止时，最近几秒的统计增量可能丢失，但记忆与播放不受影响。
+- 旧记录缺少歌曲元数据时仍只支持 V1 exact，无法进入实体聚合视图。

--- a/plugin.json
+++ b/plugin.json
@@ -21,6 +21,6 @@
   ],
   "updateUrl": "https://raw.githubusercontent.com/songloft-org/songloft-plugin-miot/main/plugin.json",
   "download_url": "https://github.com/songloft-org/songloft-plugin-miot/releases/download/v2026.7.15/miot.jsplugin.zip",
-  "entryHash": "",
-  "zipHash": ""
+  "entryHash": "e64dda62664930ce266427951261c570802e705ed8cc55748f04bd3e77182856",
+  "zipHash": "fbab524ea304c339c2338dfcc263178fdd36f77e2d6c3b6501cd83c5509c922f"
 }

--- a/src/handlers/memory.ts
+++ b/src/handlers/memory.ts
@@ -44,6 +44,19 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+function parseBody(req: HTTPRequest): Record<string, unknown> {
+  if (!req.body) return {};
+  try {
+    const text = typeof req.body === 'string'
+      ? req.body
+      : String.fromCharCode.apply(null, Array.from(req.body as Uint8Array));
+    const parsed = JSON.parse(text);
+    return isObject(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
 function isMemoryRecord(value: unknown): value is MemoryRecord {
   if (!isObject(value)) return false;
   return (
@@ -58,7 +71,12 @@ function isMemoryRecord(value: unknown): value is MemoryRecord {
     typeof value.lastUsedAt === 'string' &&
     (value.query === undefined || typeof value.query === 'string') &&
     (value.recordVersion === undefined || value.recordVersion === 2) &&
-    (value.canonicalKey === undefined || typeof value.canonicalKey === 'string')
+    (value.canonicalKey === undefined || typeof value.canonicalKey === 'string') &&
+    (value.manualAlias === undefined || typeof value.manualAlias === 'boolean') &&
+    (value.aliasSource === undefined || value.aliasSource === 'auto' || value.aliasSource === 'manual') &&
+    (value.memoryHitCount === undefined || typeof value.memoryHitCount === 'number') &&
+    (value.savedAiCalls === undefined || typeof value.savedAiCalls === 'number') &&
+    (value.lastHitReason === undefined || typeof value.lastHitReason === 'string')
   );
 }
 
@@ -241,6 +259,101 @@ export function registerMemoryHandlers(
     }
   });
 
+  router.get('/memory/stats', async (_req: HTTPRequest) => {
+    try {
+      await ensureMemoryReady();
+      await memoryService.listAmbiguities();
+      return jsonResponse({ success: true, data: memoryService.getStats() });
+    } catch (error) {
+      songloft.log.warn('[MemoryHandler] stats failed: ' + String(error));
+      return jsonResponse({ success: false, error: '读取语音记忆统计失败' }, 500);
+    }
+  });
+
+  router.get('/memory/entities', async (_req: HTTPRequest) => {
+    try {
+      await ensureMemoryReady();
+      await memoryService.listAmbiguities();
+      return jsonResponse({
+        success: true,
+        data: {
+          stats: memoryService.getStats(),
+          entities: memoryService.listEntities(),
+          unclassified: memoryService.listUnclassified(),
+        },
+      });
+    } catch (error) {
+      songloft.log.warn('[MemoryHandler] entities failed: ' + String(error));
+      return jsonResponse({ success: false, error: '读取歌曲记忆实体失败' }, 500);
+    }
+  });
+
+  router.post('/memory/aliases', async (req: HTTPRequest) => {
+    try {
+      await ensureMemoryReady();
+      const body = parseBody(req);
+      const canonicalKey = typeof body.canonicalKey === 'string' ? body.canonicalKey : '';
+      const alias = typeof body.alias === 'string' ? body.alias : '';
+      if (!canonicalKey || !alias) {
+        return jsonResponse({ success: false, error: '缺少 canonicalKey 或 alias' }, 400);
+      }
+      const result = await memoryService.addManualAlias(canonicalKey, alias);
+      if (!result.ok) {
+        const status = result.error?.startsWith('保存') ? 500 : 400;
+        return jsonResponse({ success: false, error: result.error || '添加别名失败' }, status);
+      }
+      return jsonResponse({ success: true, data: { record: result.record, stats: memoryService.getStats() } });
+    } catch (error) {
+      songloft.log.warn('[MemoryHandler] add alias failed: ' + String(error));
+      return jsonResponse({ success: false, error: '添加别名失败' }, 500);
+    }
+  });
+
+  router.delete('/memory/aliases', async (req: HTTPRequest) => {
+    try {
+      await ensureMemoryReady();
+      const query = parseQuery(req.query);
+      if (!query.canonicalKey || !query.recordId) {
+        return jsonResponse({ success: false, error: '缺少 canonicalKey 或 recordId' }, 400);
+      }
+      if (!(await memoryService.deleteEntityAlias(query.canonicalKey, query.recordId))) {
+        return jsonResponse({ success: false, error: '删除用户说法失败，原记录已保留' }, 500);
+      }
+      return jsonResponse({ success: true, data: { stats: memoryService.getStats() } });
+    } catch (error) {
+      songloft.log.warn('[MemoryHandler] delete alias failed: ' + String(error));
+      return jsonResponse({ success: false, error: '删除用户说法失败' }, 500);
+    }
+  });
+
+  router.delete('/memory/entity', async (req: HTTPRequest) => {
+    try {
+      await ensureMemoryReady();
+      const query = parseQuery(req.query);
+      if (!query.canonicalKey) {
+        return jsonResponse({ success: false, error: '缺少 canonicalKey' }, 400);
+      }
+      if (!(await memoryService.deleteEntity(query.canonicalKey))) {
+        return jsonResponse({ success: false, error: '删除歌曲记忆失败，原记录已保留' }, 500);
+      }
+      return jsonResponse({ success: true, data: { stats: memoryService.getStats() } });
+    } catch (error) {
+      songloft.log.warn('[MemoryHandler] delete entity failed: ' + String(error));
+      return jsonResponse({ success: false, error: '删除歌曲记忆失败' }, 500);
+    }
+  });
+
+  router.get('/memory/ambiguous', async (_req: HTTPRequest) => {
+    try {
+      await ensureMemoryReady();
+      const records = await memoryService.listAmbiguities();
+      return jsonResponse({ success: true, data: { count: records.length, records } });
+    } catch (error) {
+      songloft.log.warn('[MemoryHandler] ambiguities failed: ' + String(error));
+      return jsonResponse({ success: false, error: '读取歧义记录失败' }, 500);
+    }
+  });
+
   router.delete('/memory', async (req: HTTPRequest) => {
     try {
       await ensureMemoryReady();
@@ -268,7 +381,12 @@ export function registerMemoryHandlers(
       if (!(await memoryService.clear())) {
         return jsonResponse({ success: false, error: '清空记忆失败，原记录已保留' }, 500);
       }
-      return jsonResponse({ success: true, data: { count: 0 } });
+      const ambiguitiesCleared = await memoryService.clearAmbiguities();
+      return jsonResponse({
+        success: true,
+        data: { count: 0 },
+        ...(!ambiguitiesCleared ? { warning: '记忆已清空，但歧义记录清理失败' } : {}),
+      });
     } catch (error) {
       songloft.log.warn('[MemoryHandler] clear failed: ' + String(error));
       return jsonResponse({ success: false, error: '清空记忆失败' }, 500);

--- a/src/memory/memory_resolver.ts
+++ b/src/memory/memory_resolver.ts
@@ -128,6 +128,11 @@ export class MemoryResolver {
         reason: duplicateTitleWithoutArtist ? 'duplicate_title' : 'candidate_margin_too_small',
         candidateCount: scored.length,
         margin,
+        candidates: scored.slice(0, 5).map(item => ({
+          canonicalKey: item.entity.canonicalKey,
+          songName: item.entity.representative.songName || '',
+          artist: item.entity.representative.artist || '',
+        })),
       };
     }
 

--- a/src/memory/memory_service.ts
+++ b/src/memory/memory_service.ts
@@ -4,12 +4,17 @@ import { MemoryEntityIndex, canonicalKeyForRecord } from './entity_index';
 import { MemoryResolver } from './memory_resolver';
 import { SongloftStorageMemoryAdapter } from './storage_adapter';
 import type {
+  MemoryAmbiguityRecord,
+  MemoryEntityView,
   MemoryFindResult,
+  MemoryMutationResult,
   MemoryRecord,
   MemoryRecordInput,
   MemoryResolveResult,
+  MemoryStats,
   MemoryStorageAdapter,
   MemoryStoreSnapshot,
+  MemoryUnclassifiedView,
 } from './types';
 import { DEFAULT_MEMORY_MAX_RECORDS, normalizeMemoryMaxRecords } from './types';
 
@@ -32,6 +37,26 @@ function findById(records: Map<string, MemoryRecord>, id: string): MemoryRecord 
   return null;
 }
 
+const AMBIGUITY_STORAGE_KEY = 'memory:v3:ambiguous';
+const MAX_AMBIGUITY_RECORDS = 20;
+const HIT_FLUSH_DELAY_MS = 5000;
+const AMBIGUITY_FLUSH_DELAY_MS = 2000;
+const BLOCKED_MANUAL_ALIASES = new Set([
+  '歌', '音乐', '播放', '听歌', '暂停', '暂停播放', '暂停音乐', '停止', '停止播放', '停一下',
+  '继续', '继续播放', '下一首', '上一首', '切歌', '换一首', '音量', '声音', '顺序播放', '随机播放',
+  '单曲循环', '列表循环', 'pause', 'stop', 'next', 'previous',
+]);
+
+interface PendingHit {
+  count: number;
+  lastUsedAt: string;
+  reason: string;
+}
+
+function localHitCount(record: MemoryRecord): number {
+  return record.memoryHitCount ?? Math.max(0, record.successCount - 1);
+}
+
 export class MemoryService {
   private readonly adapter: MemoryStorageAdapter;
   private records: Map<string, MemoryRecord> = new Map();
@@ -42,6 +67,12 @@ export class MemoryService {
   private maxRecords: number;
   private initPromise: Promise<void> | null = null;
   private writeQueue: Promise<void> = Promise.resolve();
+  private pendingHits = new Map<string, PendingHit>();
+  private hitFlushTimer: any = null;
+  private ambiguities: MemoryAmbiguityRecord[] = [];
+  private ambiguitiesLoaded = false;
+  private ambiguityStorageHealthy = false;
+  private ambiguityFlushTimer: any = null;
 
   constructor(
     adapter: MemoryStorageAdapter = new SongloftStorageMemoryAdapter(),
@@ -138,6 +169,12 @@ export class MemoryService {
       if (matched && matched.normalizedQuery !== normalizedQuery) {
         candidate.set(matched.normalizedQuery, this.upgradeRecord({
           ...matched,
+          memoryHitCount: input.memoryHitReason
+            ? (matched.memoryHitCount ?? Math.max(0, matched.successCount - 1))
+            : matched.memoryHitCount,
+          savedAiCalls: input.memoryHitReason
+            ? (matched.savedAiCalls ?? matched.memoryHitCount ?? Math.max(0, matched.successCount - 1))
+            : matched.savedAiCalls,
           hitCount: matched.hitCount + 1,
           successCount: matched.successCount + 1,
           updatedAt: timestamp,
@@ -158,6 +195,11 @@ export class MemoryService {
         playlistName: input.playlistName,
         songIndex: input.songIndex,
         canonicalKey: existing?.canonicalKey ?? matched?.canonicalKey,
+        manualAlias: existing?.manualAlias,
+        aliasSource: existing?.aliasSource ?? 'auto',
+        memoryHitCount: (existing?.memoryHitCount ?? 0) + (input.memoryHitReason ? 1 : 0),
+        savedAiCalls: (existing?.savedAiCalls ?? 0) + (input.memoryHitReason ? 1 : 0),
+        lastHitReason: input.memoryHitReason ?? existing?.lastHitReason,
         hitCount: (existing?.hitCount ?? 0) + 1,
         successCount: (existing?.successCount ?? 0) + 1,
         failureCount: existing?.failureCount ?? 0,
@@ -256,7 +298,255 @@ export class MemoryService {
   }
 
   async clear(): Promise<boolean> {
-    return this.enqueueWrite('clear', async () => this.commitCandidate(new Map()));
+    return this.enqueueWrite('clear', async () => {
+      const saved = await this.commitCandidate(new Map());
+      if (saved) this.pendingHits.clear();
+      return saved;
+    });
+  }
+
+  queueHit(recordId: string, reason: string): void {
+    try {
+      if (!this.initialized || !this.findById(recordId)) return;
+      const timestamp = nowIso();
+      const pending = this.pendingHits.get(recordId);
+      this.pendingHits.set(recordId, {
+        count: (pending?.count ?? 0) + 1,
+        lastUsedAt: timestamp,
+        reason,
+      });
+      if (!this.hitFlushTimer) {
+        this.hitFlushTimer = setTimeout(() => {
+          this.hitFlushTimer = null;
+          void this.flushPendingHits();
+        }, HIT_FLUSH_DELAY_MS);
+      }
+    } catch (error) {
+      songloft.log.warn('[VoiceMemoryV3] error stage="queue_hit" error="' + String(error) + '"');
+    }
+  }
+
+  async flushPendingHits(): Promise<boolean> {
+    if (this.hitFlushTimer) {
+      clearTimeout(this.hitFlushTimer);
+      this.hitFlushTimer = null;
+    }
+    if (this.pendingHits.size === 0) return true;
+    const batch = this.pendingHits;
+    this.pendingHits = new Map();
+    const saved = await this.enqueueWrite('flushHits', async () => {
+      const candidate = new Map(this.records);
+      for (const [recordId, pending] of batch) {
+        const record = findById(candidate, recordId);
+        if (!record) continue;
+        candidate.set(record.normalizedQuery, this.upgradeRecord({
+          ...record,
+          hitCount: record.hitCount + pending.count,
+          successCount: record.successCount + pending.count,
+          memoryHitCount: (record.memoryHitCount ?? 0) + pending.count,
+          savedAiCalls: (record.savedAiCalls ?? 0) + pending.count,
+          lastHitReason: pending.reason,
+          updatedAt: pending.lastUsedAt,
+          lastUsedAt: pending.lastUsedAt,
+        }));
+      }
+      return this.commitCandidate(candidate);
+    });
+    if (!saved) {
+      for (const [recordId, pending] of batch) {
+        const current = this.pendingHits.get(recordId);
+        this.pendingHits.set(recordId, {
+          count: (current?.count ?? 0) + pending.count,
+          lastUsedAt: current?.lastUsedAt && current.lastUsedAt > pending.lastUsedAt ? current.lastUsedAt : pending.lastUsedAt,
+          reason: current?.reason ?? pending.reason,
+        });
+      }
+    }
+    return saved;
+  }
+
+  listEntities(): MemoryEntityView[] {
+    const views: MemoryEntityView[] = [];
+    for (const entity of this.entityIndex.entities.values()) {
+      const records = Array.from(entity.recordIds)
+        .map(id => this.entityIndex.recordById.get(id))
+        .filter((record): record is MemoryRecord => !!record);
+      if (records.length === 0) continue;
+      const aliases = records.map(record => {
+        const pending = this.pendingHits.get(record.id)?.count ?? 0;
+        return {
+          id: record.id,
+          query: record.query || record.normalizedQuery,
+          normalizedQuery: record.normalizedQuery,
+          manualAlias: record.manualAlias === true,
+          aliasSource: record.aliasSource === 'manual' ? 'manual' as const : 'auto' as const,
+          hitCount: record.hitCount + pending,
+          localHitCount: localHitCount(record) + pending,
+          lastUsedAt: this.pendingHits.get(record.id)?.lastUsedAt ?? record.lastUsedAt,
+          updatedAt: this.pendingHits.get(record.id)?.lastUsedAt ?? record.updatedAt,
+        };
+      }).sort((a, b) => b.lastUsedAt.localeCompare(a.lastUsedAt));
+      views.push({
+        canonicalKey: entity.canonicalKey,
+        songId: entity.representative.songId,
+        songName: entity.representative.songName || '',
+        artist: entity.representative.artist || '',
+        queryCount: records.length,
+        localHitCount: aliases.reduce((sum, item) => sum + item.localHitCount, 0),
+        successCount: records.reduce((sum, record) => sum + record.successCount, 0),
+        failureCount: records.reduce((sum, record) => sum + record.failureCount, 0),
+        lastUsedAt: aliases[0]?.lastUsedAt || entity.representative.lastUsedAt,
+        updatedAt: aliases[0]?.updatedAt || entity.representative.updatedAt,
+        aliases,
+      });
+    }
+    return views.sort((a, b) => b.lastUsedAt.localeCompare(a.lastUsedAt));
+  }
+
+  listUnclassified(): MemoryUnclassifiedView[] {
+    return Array.from(this.records.values())
+      .filter(record => !this.entityIndex.derivedByRecordId.has(record.id))
+      .map(record => ({
+        id: record.id,
+        query: record.query || record.normalizedQuery,
+        normalizedQuery: record.normalizedQuery,
+        type: record.type,
+        songName: record.songName || '',
+        artist: record.artist || '',
+        hitCount: record.hitCount,
+        successCount: record.successCount,
+        failureCount: record.failureCount,
+        lastUsedAt: record.lastUsedAt,
+        updatedAt: record.updatedAt,
+      }))
+      .sort((a, b) => b.lastUsedAt.localeCompare(a.lastUsedAt));
+  }
+
+  getStats(): MemoryStats {
+    const records = Array.from(this.records.values());
+    let localHits = 0;
+    let savedAiCalls = 0;
+    for (const record of records) {
+      const pending = this.pendingHits.get(record.id)?.count ?? 0;
+      localHits += localHitCount(record) + pending;
+      savedAiCalls += (record.savedAiCalls ?? localHitCount(record)) + pending;
+    }
+    return {
+      recordCount: records.length,
+      entityCount: this.entityIndex.entities.size,
+      unclassifiedCount: this.listUnclassified().length,
+      localHitCount: localHits,
+      savedAiCalls,
+      ambiguousCount: this.ambiguities.length,
+    };
+  }
+
+  async addManualAlias(canonicalKey: string, alias: string): Promise<MemoryMutationResult> {
+    const trimmed = (alias || '').trim();
+    const length = Array.from(trimmed).length;
+    const normalizedQuery = this.normalizeQuery(trimmed);
+    if (!normalizedQuery) return { ok: false, error: '别名不能为空' };
+    if (length < 2 || length > 30) return { ok: false, error: '别名长度必须为 2 到 30 个字符' };
+    if (BLOCKED_MANUAL_ALIASES.has(normalizedQuery)) return { ok: false, error: '该词过于宽泛或属于固定控制命令' };
+    const entity = this.entityIndex.entities.get(canonicalKey);
+    if (!entity) return { ok: false, error: '未找到歌曲实体' };
+    if (this.records.has(normalizedQuery) || this.entityIndex.aliasIndex.has(normalizedQuery) || entity.aliases.includes(normalizedQuery)) {
+      return { ok: false, error: '该别名已存在' };
+    }
+
+    let created: MemoryRecord | undefined;
+    const ok = await this.enqueueWrite('addManualAlias', async () => {
+      const currentEntity = this.entityIndex.entities.get(canonicalKey);
+      if (!currentEntity || this.records.has(normalizedQuery) || this.entityIndex.aliasIndex.has(normalizedQuery)) return false;
+      const source = currentEntity.representative;
+      const timestamp = nowIso();
+      created = this.upgradeRecord({
+        ...source,
+        id: `memory_${hashString(normalizedQuery)}`,
+        query: trimmed,
+        normalizedQuery,
+        canonicalKey,
+        manualAlias: true,
+        aliasSource: 'manual',
+        hitCount: 0,
+        successCount: 0,
+        failureCount: 0,
+        memoryHitCount: 0,
+        savedAiCalls: 0,
+        lastHitReason: undefined,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        lastUsedAt: timestamp,
+      });
+      const candidate = new Map(this.records);
+      candidate.set(normalizedQuery, created);
+      return this.commitCandidate(candidate);
+    });
+    return ok && created ? { ok: true, record: created } : { ok: false, error: '保存别名失败，原记忆未修改' };
+  }
+
+  async deleteEntityAlias(canonicalKey: string, recordId: string): Promise<boolean> {
+    return this.enqueueWrite('deleteEntityAlias', async () => {
+      const derived = this.entityIndex.derivedByRecordId.get(recordId);
+      if (!derived || derived.canonicalKey !== canonicalKey) return false;
+      const candidate = new Map(this.records);
+      candidate.delete(derived.record.normalizedQuery);
+      const saved = await this.commitCandidate(candidate);
+      if (saved) this.pendingHits.delete(recordId);
+      return saved;
+    });
+  }
+
+  async deleteEntity(canonicalKey: string): Promise<boolean> {
+    return this.enqueueWrite('deleteEntity', async () => {
+      const entity = this.entityIndex.entities.get(canonicalKey);
+      if (!entity) return false;
+      const candidate = new Map(this.records);
+      for (const recordId of entity.recordIds) {
+        const record = findById(candidate, recordId);
+        if (record) candidate.delete(record.normalizedQuery);
+      }
+      const saved = await this.commitCandidate(candidate);
+      if (saved) for (const recordId of entity.recordIds) this.pendingHits.delete(recordId);
+      return saved;
+    });
+  }
+
+  async listAmbiguities(): Promise<MemoryAmbiguityRecord[]> {
+    await this.ensureAmbiguitiesLoaded();
+    return this.ambiguities.map(item => ({ ...item, candidates: item.candidates.map(candidate => ({ ...candidate })) }));
+  }
+
+  async recordAmbiguity(query: string, result: MemoryResolveResult): Promise<void> {
+    try {
+      await this.ensureAmbiguitiesLoaded();
+      if (!this.ambiguityStorageHealthy) return;
+      const normalizedQuery = this.normalizeQuery(query);
+      if (!normalizedQuery) return;
+      const timestamp = nowIso();
+      const existing = this.ambiguities.find(item => item.normalizedQuery === normalizedQuery);
+      const record: MemoryAmbiguityRecord = {
+        query,
+        normalizedQuery,
+        reason: result.reason || 'ambiguous',
+        candidateCount: result.candidateCount ?? result.candidates?.length ?? 0,
+        candidates: (result.candidates || []).slice(0, 5),
+        lastSeenAt: timestamp,
+        occurrenceCount: (existing?.occurrenceCount ?? 0) + 1,
+      };
+      this.ambiguities = [record, ...this.ambiguities.filter(item => item.normalizedQuery !== normalizedQuery)]
+        .slice(0, MAX_AMBIGUITY_RECORDS);
+      this.scheduleAmbiguitySave();
+    } catch (error) {
+      songloft.log.warn('[VoiceMemoryV3] error stage="record_ambiguous" error="' + String(error) + '"');
+    }
+  }
+
+  async clearAmbiguities(): Promise<boolean> {
+    await this.ensureAmbiguitiesLoaded();
+    if (!this.ambiguityStorageHealthy) return false;
+    this.ambiguities = [];
+    return this.saveAmbiguities();
   }
 
   getIndexStats(): { records: number; entities: number; aliases: number } {
@@ -265,6 +555,57 @@ export class MemoryService {
       entities: this.entityIndex.entities.size,
       aliases: this.entityIndex.aliasIndex.size,
     };
+  }
+
+  private async ensureAmbiguitiesLoaded(): Promise<void> {
+    if (this.ambiguitiesLoaded) return;
+    this.ambiguitiesLoaded = true;
+    try {
+      const raw = await songloft.storage.get(AMBIGUITY_STORAGE_KEY);
+      if (raw === null || raw === undefined || raw === '') {
+        this.ambiguities = [];
+        this.ambiguityStorageHealthy = true;
+        return;
+      }
+      const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+      if (!parsed || typeof parsed !== 'object' || (parsed as any).version !== 1 || !Array.isArray((parsed as any).records)) {
+        throw new Error('invalid ambiguity snapshot');
+      }
+      this.ambiguities = (parsed as any).records.filter((item: any) =>
+        item && typeof item.query === 'string' && typeof item.normalizedQuery === 'string' &&
+        typeof item.reason === 'string' && typeof item.candidateCount === 'number' &&
+        Array.isArray(item.candidates) && typeof item.lastSeenAt === 'string' &&
+        typeof item.occurrenceCount === 'number',
+      ).slice(0, MAX_AMBIGUITY_RECORDS);
+      this.ambiguityStorageHealthy = true;
+    } catch (error) {
+      this.ambiguities = [];
+      this.ambiguityStorageHealthy = false;
+      songloft.log.warn('[VoiceMemoryV3] error stage="load_ambiguous" error="' + String(error) + '"');
+    }
+  }
+
+  private scheduleAmbiguitySave(): void {
+    if (this.ambiguityFlushTimer) return;
+    this.ambiguityFlushTimer = setTimeout(() => {
+      this.ambiguityFlushTimer = null;
+      void this.saveAmbiguities();
+    }, AMBIGUITY_FLUSH_DELAY_MS);
+  }
+
+  private async saveAmbiguities(): Promise<boolean> {
+    if (!this.ambiguityStorageHealthy) return false;
+    try {
+      await songloft.storage.set(AMBIGUITY_STORAGE_KEY, JSON.stringify({
+        version: 1,
+        records: this.ambiguities.slice(0, MAX_AMBIGUITY_RECORDS),
+        updatedAt: nowIso(),
+      }));
+      return true;
+    } catch (error) {
+      songloft.log.warn('[VoiceMemoryV3] error stage="save_ambiguous" error="' + String(error) + '"');
+      return false;
+    }
   }
 
   private upgradeRecord(record: MemoryRecord): MemoryRecord {
@@ -338,6 +679,7 @@ export class MemoryService {
 
   private enterDegradedState(stage: string, error: unknown): void {
     this.records.clear();
+    this.pendingHits.clear();
     this.entityIndex.clear();
     this.initialized = false;
     this.storageHealthy = false;

--- a/src/memory/self_test.ts
+++ b/src/memory/self_test.ts
@@ -3,6 +3,7 @@ import { MemoryResolver } from './memory_resolver';
 import { MemoryService } from './memory_service';
 import { normalizeMemoryQuery } from './query_normalizer';
 import type { MemoryLoadResult, MemoryRecord, MemoryStorageAdapter, MemoryStoreSnapshot } from './types';
+import { normalizeMemoryMaxRecords } from './types';
 
 export interface MemoryV2SelfTestCheck {
   name: string;
@@ -111,11 +112,31 @@ export async function runMemoryV2SelfTest(): Promise<MemoryV2SelfTestResult> {
   ];
   check('same_song_queries_one_entity', resolve(sameSongRecords, '放晴天').index.entities.size === 1);
 
+  const v3Adapter = new InMemoryAdapter([sunny]);
+  const v3Service = new MemoryService(v3Adapter);
+  await v3Service.init();
+  const addedAlias = await v3Service.addManualAlias('song:id:101', '再听一遍晴天');
+  check('v3_manual_alias_saved', addedAlias.ok && v3Service.findByQuery('再听一遍晴天')?.manualAlias === true);
+  check('v3_entity_aggregation', v3Service.listEntities().length === 1 && v3Service.listEntities()[0].queryCount === 2);
+  v3Service.queueHit(sunny.id, 'self_test_exact');
+  check('v3_pending_hit_visible', v3Service.getStats().localHitCount >= 1);
+  await v3Service.flushPendingHits();
+  check('v3_debounced_hit_saved', (v3Service.findById(sunny.id)?.memoryHitCount ?? 0) === 1);
+  const blockedAlias = await v3Service.addManualAlias('song:id:101', '暂停播放');
+  check('v3_fixed_control_alias_blocked', !blockedAlias.ok);
+  if (addedAlias.record) await v3Service.deleteEntityAlias('song:id:101', addedAlias.record.id);
+  check('v3_alias_delete_rebuilds_index', v3Service.findByQuery('再听一遍晴天') === null);
+  await v3Service.deleteEntity('song:id:101');
+  check('v3_entity_delete_rebuilds_index', v3Service.count() === 0 && v3Service.getIndexStats().entities === 0);
+  check('v3_max_records_clamped', normalizeMemoryMaxRecords(1000) === 500);
+
   const duplicated = [
     record('later-1', '播放刘若英后来', '后来', '刘若英', 201),
     record('later-2', '播放其他歌手后来', '后来', '其他歌手', 202),
   ];
-  check('duplicate_title_ambiguous', resolve(duplicated, '播放后来').result.status === 'ambiguous');
+  const ambiguousResult = resolve(duplicated, '播放后来').result;
+  check('duplicate_title_ambiguous', ambiguousResult.status === 'ambiguous');
+  check('v3_ambiguity_candidates_bounded', (ambiguousResult.candidates?.length ?? 0) === 2);
   check('duplicate_title_full_artist_hit', resolve(duplicated, '播放刘若英的后来').result.status === 'entity_hit');
 
   const shortCollision = [
@@ -137,6 +158,9 @@ export async function runMemoryV2SelfTest(): Promise<MemoryV2SelfTestResult> {
   await legacyService.init();
   check('legacy_v1_loads', legacyService.findByQuery('旧口令')?.id === legacy.id);
   check('legacy_without_song_not_v2', legacyService.resolveEntity('旧口令').status !== 'entity_hit');
+  check('v3_legacy_visible_as_unclassified', legacyService.listUnclassified().length === 1 && legacyService.getStats().recordCount === 1);
+  await legacyService.deleteById(legacy.id);
+  check('v3_unclassified_delete_keeps_indexes_consistent', legacyService.listUnclassified().length === 0 && legacyService.count() === 0);
 
   const deleteService = new MemoryService(new InMemoryAdapter([sunny]));
   await deleteService.init();
@@ -203,7 +227,7 @@ export async function runMemoryV2SelfTest(): Promise<MemoryV2SelfTestResult> {
   ]);
   check('mixed_concurrency_consistent', concurrentService.count() <= 10 && concurrentService.getIndexStats().records === concurrentService.count());
 
-  for (const size of [10, 100, 1000]) {
+  for (const size of [10, 100, 500]) {
     const records = Array.from({ length: size }, (_, i) => record(`perf-${size}-${i}`, `播放性能歌曲${i}`, `性能歌曲${i}`, '性能歌手', 10000 + i));
     const start = Date.now();
     const index = new MemoryEntityIndex();

--- a/src/memory/storage_adapter.ts
+++ b/src/memory/storage_adapter.ts
@@ -35,7 +35,12 @@ function isMemoryRecord(value: unknown): value is MemoryRecord {
     typeof value.lastUsedAt === 'string' &&
     (value.query === undefined || typeof value.query === 'string') &&
     (value.recordVersion === undefined || value.recordVersion === 2) &&
-    (value.canonicalKey === undefined || typeof value.canonicalKey === 'string')
+    (value.canonicalKey === undefined || typeof value.canonicalKey === 'string') &&
+    (value.manualAlias === undefined || typeof value.manualAlias === 'boolean') &&
+    (value.aliasSource === undefined || value.aliasSource === 'auto' || value.aliasSource === 'manual') &&
+    (value.memoryHitCount === undefined || typeof value.memoryHitCount === 'number') &&
+    (value.savedAiCalls === undefined || typeof value.savedAiCalls === 'number') &&
+    (value.lastHitReason === undefined || typeof value.lastHitReason === 'string')
   );
 }
 

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -2,7 +2,7 @@ export type MemoryTargetType = 'play_song' | 'play_playlist';
 
 export const DEFAULT_MEMORY_MAX_RECORDS = 100;
 export const MIN_MEMORY_MAX_RECORDS = 10;
-export const MAX_MEMORY_MAX_RECORDS = 1000;
+export const MAX_MEMORY_MAX_RECORDS = 500;
 
 export function normalizeMemoryMaxRecords(value: unknown): number {
   const parsed = Number(value);
@@ -29,6 +29,11 @@ export interface MemoryRecord {
   lastUsedAt: string;
   recordVersion?: 2;
   canonicalKey?: string;
+  manualAlias?: boolean;
+  aliasSource?: 'auto' | 'manual';
+  memoryHitCount?: number;
+  savedAiCalls?: number;
+  lastHitReason?: string;
 }
 
 export interface MemoryRecordInput {
@@ -41,6 +46,78 @@ export interface MemoryRecordInput {
   playlistName?: string;
   songIndex?: number;
   matchedRecordId?: string;
+  memoryHitReason?: string;
+}
+
+export interface MemoryResolveCandidate {
+  canonicalKey: string;
+  songName: string;
+  artist: string;
+}
+
+export interface MemoryAmbiguityRecord {
+  query: string;
+  normalizedQuery: string;
+  reason: string;
+  candidateCount: number;
+  candidates: MemoryResolveCandidate[];
+  lastSeenAt: string;
+  occurrenceCount: number;
+}
+
+export interface MemoryAliasView {
+  id: string;
+  query: string;
+  normalizedQuery: string;
+  manualAlias: boolean;
+  aliasSource: 'auto' | 'manual';
+  hitCount: number;
+  localHitCount: number;
+  lastUsedAt: string;
+  updatedAt: string;
+}
+
+export interface MemoryEntityView {
+  canonicalKey: string;
+  songId?: number;
+  songName: string;
+  artist: string;
+  queryCount: number;
+  localHitCount: number;
+  successCount: number;
+  failureCount: number;
+  lastUsedAt: string;
+  updatedAt: string;
+  aliases: MemoryAliasView[];
+}
+
+export interface MemoryUnclassifiedView {
+  id: string;
+  query: string;
+  normalizedQuery: string;
+  type: MemoryTargetType;
+  songName: string;
+  artist: string;
+  hitCount: number;
+  successCount: number;
+  failureCount: number;
+  lastUsedAt: string;
+  updatedAt: string;
+}
+
+export interface MemoryStats {
+  recordCount: number;
+  entityCount: number;
+  unclassifiedCount: number;
+  localHitCount: number;
+  savedAiCalls: number;
+  ambiguousCount: number;
+}
+
+export interface MemoryMutationResult {
+  ok: boolean;
+  error?: string;
+  record?: MemoryRecord;
 }
 
 export interface MemoryStoreSnapshot {
@@ -70,6 +147,7 @@ export interface MemoryResolveResult {
   reason?: string;
   candidateCount?: number;
   margin?: number;
+  candidates?: MemoryResolveCandidate[];
 }
 
 export interface MemoryStorageAdapter {

--- a/src/voicecmd/engine.ts
+++ b/src/voicecmd/engine.ts
@@ -341,6 +341,9 @@ export class VoiceEngine {
         const resolved = this.memoryService.resolveEntity(query);
         if (resolved.status === 'ambiguous') {
           songloft.log.info(`[VoiceMemoryV2] ambiguous query="${query}" candidates=${resolved.candidateCount ?? 0} reason="${resolved.reason || 'ambiguous'}"`);
+          void this.memoryService.recordAmbiguity(query, resolved).catch(error => {
+            songloft.log.warn('[VoiceMemoryV3] error fallback stage="record_ambiguous" error="' + String(error) + '"');
+          });
           return false;
         }
         if (resolved.status !== 'entity_hit' || !resolved.record) {
@@ -370,9 +373,13 @@ export class VoiceEngine {
 
       if (matchMode === 'entity_hit') {
         songloft.log.info(`[VoiceMemoryV2] entity_hit query="${query}" song="${playedSong.songName}" artist="${playedSong.artist}" score=${(score ?? 0).toFixed(2)} reason="${reason}" canonicalKey="${canonicalKey || ''}"`);
-        this.queueMemorySuccess(query, playedSong, record.id);
+        this.queueMemorySuccess(query, playedSong, record.id, reason);
       } else {
-        this.queueMemorySuccess(query, playedSong);
+        if (record.recordVersion !== 2 || !record.canonicalKey) {
+          this.queueMemorySuccess(query, playedSong, record.id, 'v1_exact');
+        } else {
+          this.memoryService.queueHit(record.id, 'v1_exact');
+        }
       }
       return true;
     } catch (error) {
@@ -434,7 +441,7 @@ export class VoiceEngine {
     return null;
   }
 
-  private queueMemorySuccess(query: string, song: PlayedSong, matchedRecordId?: string): void {
+  private queueMemorySuccess(query: string, song: PlayedSong, matchedRecordId?: string, memoryHitReason?: string): void {
     songloft.log.info(`[VoiceMemoryV2] lazy_migrate queued query="${query}" song="${song.songName}"`);
     void this.memoryService.recordSuccess({
       query,
@@ -446,6 +453,7 @@ export class VoiceEngine {
       playlistName: song.playlistName,
       songIndex: song.songIndex,
       matchedRecordId,
+      memoryHitReason,
     }).then(saved => {
       if (saved) {
         songloft.log.info(`[VoiceMemoryV2] lazy_migrate done query="${query}"`);

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2204,6 +2204,117 @@ html[data-theme="dark"] {
     color: var(--md-on-surface-variant);
 }
 
+.memory-ai-note {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    margin-top: 12px;
+    padding: 10px 0;
+    border-top: 1px solid var(--md-outline-variant);
+    color: var(--md-on-surface-variant);
+    font-size: 12px;
+    line-height: 1.6;
+}
+
+.memory-ai-note .material-symbols-outlined {
+    flex: 0 0 auto;
+    margin-top: 1px;
+    font-size: 18px;
+    color: var(--md-primary);
+}
+
+.memory-management-toggle,
+.memory-entity-toggle,
+.memory-subsection-toggle {
+    width: 100%;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    text-align: left;
+}
+
+.memory-management-toggle {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 10px;
+    margin-top: 4px;
+    padding: 12px 0;
+    border-top: 1px solid var(--md-outline-variant);
+    border-bottom: 1px solid var(--md-outline-variant);
+}
+
+.memory-management-title {
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.memory-management-summary {
+    overflow: hidden;
+    color: var(--md-on-surface-variant);
+    font-size: 12px;
+    line-height: 1.5;
+    text-align: right;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.memory-management-summary strong {
+    color: var(--md-on-surface);
+    font-variant-numeric: tabular-nums;
+}
+
+.memory-management-toggle .memory-chevron,
+.memory-entity-toggle > .material-symbols-outlined {
+    transition: transform .18s ease;
+}
+
+.memory-management-toggle[aria-expanded="true"] .memory-chevron,
+.memory-entity-toggle[aria-expanded="true"] > .material-symbols-outlined {
+    transform: rotate(90deg);
+}
+
+.memory-management-panel {
+    padding-top: 12px;
+}
+
+.memory-stats {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1px;
+    overflow: hidden;
+    border: 1px solid var(--md-outline-variant);
+    border-radius: var(--md-radius-sm);
+    background: var(--md-outline-variant);
+}
+
+.memory-stat {
+    min-width: 0;
+    padding: 10px 6px;
+    background: var(--md-surface);
+    text-align: center;
+}
+
+.memory-stat strong,
+.memory-stat span {
+    display: block;
+}
+
+.memory-stat strong {
+    font-size: 18px;
+    font-variant-numeric: tabular-nums;
+}
+
+.memory-stat span {
+    margin-top: 3px;
+    overflow: hidden;
+    color: var(--md-on-surface-variant);
+    font-size: 11px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .memory-toolbar {
     display: flex;
     align-items: center;
@@ -2236,6 +2347,144 @@ html[data-theme="dark"] {
 
 .memory-list {
     min-height: 48px;
+    max-height: 50vh;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+}
+
+.memory-entity {
+    border-bottom: 1px solid var(--md-outline-variant);
+}
+
+.memory-entity:last-child {
+    border-bottom: 0;
+}
+
+.memory-entity-toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 2px;
+}
+
+.memory-entity-main {
+    flex: 1;
+    min-width: 0;
+}
+
+.memory-entity-title {
+    overflow: hidden;
+    font-size: 14px;
+    font-weight: 600;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.memory-entity-meta {
+    margin-top: 4px;
+    overflow: hidden;
+    color: var(--md-on-surface-variant);
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.45;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.memory-entity-details {
+    padding: 0 2px 14px 12px;
+}
+
+.memory-alias-heading {
+    margin-bottom: 4px;
+    color: var(--md-on-surface-variant);
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.memory-alias-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 38px;
+    border-bottom: 1px solid var(--md-outline-variant);
+}
+
+.memory-alias-text {
+    display: flex;
+    flex: 1;
+    min-width: 0;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+}
+
+.memory-alias-text > span:first-child {
+    overflow-wrap: anywhere;
+}
+
+.memory-alias-badge {
+    flex: 0 0 auto;
+    padding: 1px 5px;
+    border: 1px solid var(--md-outline-variant);
+    border-radius: var(--md-radius-sm);
+    color: var(--md-on-surface-variant);
+    font-size: 10px;
+}
+
+.memory-alias-form {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 40px;
+    gap: 6px;
+    margin-top: 10px;
+}
+
+.memory-entity-delete {
+    margin-top: 8px;
+    color: var(--md-error);
+}
+
+.memory-empty-inline {
+    padding: 10px 0;
+    color: var(--md-on-surface-variant);
+    font-size: 12px;
+}
+
+.memory-unclassified-section,
+.memory-ambiguity-section {
+    border-top: 1px solid var(--md-outline-variant);
+}
+
+.memory-subsection-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 2px;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.memory-subsection-toggle strong {
+    font-variant-numeric: tabular-nums;
+}
+
+.memory-unclassified-list,
+.memory-ambiguity-list {
+    max-height: 220px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+}
+
+.memory-unclassified-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.memory-unclassified-item,
+.memory-ambiguity-item {
+    padding: 10px 2px;
+    border-top: 1px solid var(--md-outline-variant);
 }
 
 .memory-item {
@@ -2287,6 +2536,34 @@ html[data-theme="dark"] {
     min-height: 72px;
     padding: 20px 12px;
     font-size: 13px;
+}
+
+@media (min-width: 600px) {
+    .memory-list {
+        max-height: 480px;
+    }
+}
+
+@media (max-width: 599px) {
+    .memory-management-toggle {
+        grid-template-columns: minmax(0, 1fr) auto;
+    }
+
+    .memory-management-summary {
+        grid-column: 1 / -1;
+        grid-row: 2;
+        text-align: left;
+        white-space: normal;
+    }
+
+    .memory-management-toggle .memory-chevron {
+        grid-column: 2;
+        grid-row: 1;
+    }
+
+    .memory-stats {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
 }
 
 /* Status Chips */

--- a/static/index.html
+++ b/static/index.html
@@ -580,23 +580,54 @@
                     </div>
                     <div class="form-group" style="margin-top:12px">
                         <label class="form-label" for="voiceMemoryMaxRecords">最大记忆数量</label>
-                        <input type="number" class="text-field" id="voiceMemoryMaxRecords" min="10" max="1000" step="10" value="100">
-                        <div class="memory-help">超过上限时自动淘汰最久未使用的记忆，范围 10–1000</div>
+                        <input type="number" class="text-field" id="voiceMemoryMaxRecords" min="10" max="500" step="10" value="100">
+                        <div class="memory-help">超过上限时自动淘汰最久未使用的记忆，范围 10–500</div>
                     </div>
-                    <div class="memory-toolbar">
-                        <div class="memory-count">
-                            已保存 <strong id="voiceMemoryCount">0</strong> 条
+                    <div class="memory-ai-note">
+                        <span class="material-symbols-outlined">info</span>
+                        <span>建议同时开启 AI 口令分析用于学习新口令；已有记忆命中时不会重复调用 AI。</span>
+                    </div>
+                    <button class="memory-management-toggle" id="memoryManagementToggle" type="button" aria-expanded="false" aria-controls="memoryManagementPanel">
+                        <span class="memory-management-title">记忆管理</span>
+                        <span class="memory-management-summary">
+                            已保存 <strong id="voiceMemoryCount">0</strong> 条 / 已学习 <strong id="voiceMemoryEntityCount">0</strong> 首 / 本地命中 <strong id="voiceMemoryHitCount">0</strong> 次<span id="memoryUnclassifiedSummary" hidden> / 未归类 <strong id="voiceMemoryUnclassifiedCount">0</strong> 条</span>
+                        </span>
+                        <span class="material-symbols-outlined memory-chevron">chevron_right</span>
+                    </button>
+                    <div class="memory-management-panel" id="memoryManagementPanel" hidden>
+                        <div class="memory-stats" aria-label="语音记忆统计">
+                            <div class="memory-stat"><strong id="memoryStatEntities">0</strong><span>已学习歌曲</span></div>
+                            <div class="memory-stat"><strong id="memoryStatQueries">0</strong><span>用户说法</span></div>
+                            <div class="memory-stat"><strong id="memoryStatHits">0</strong><span>本地命中</span></div>
+                            <div class="memory-stat"><strong id="memoryStatSavedAi">0</strong><span>节省 AI 调用</span></div>
                         </div>
-                        <button class="btn-icon" id="refreshVoiceMemoryBtn" title="刷新记忆列表" aria-label="刷新记忆列表">
-                            <span class="material-symbols-outlined">refresh</span>
-                        </button>
-                        <button class="btn-text memory-clear-btn" id="clearVoiceMemoryBtn">
-                            <span class="material-symbols-outlined">delete_sweep</span>
-                            清空全部
-                        </button>
-                    </div>
-                    <div class="memory-list" id="voiceMemoryList">
-                        <div class="empty-state memory-empty">加载中...</div>
+                        <div class="memory-toolbar">
+                            <div class="memory-count">按歌曲聚合展示</div>
+                            <button class="btn-icon" id="refreshVoiceMemoryBtn" title="刷新记忆列表" aria-label="刷新记忆列表">
+                                <span class="material-symbols-outlined">refresh</span>
+                            </button>
+                            <button class="btn-text memory-clear-btn" id="clearVoiceMemoryBtn">
+                                <span class="material-symbols-outlined">delete_sweep</span>
+                                清空全部
+                            </button>
+                        </div>
+                        <div class="memory-list" id="voiceMemoryList">
+                            <div class="empty-state memory-empty">展开后加载记忆</div>
+                        </div>
+                        <div class="memory-unclassified-section">
+                            <button class="memory-subsection-toggle" id="memoryUnclassifiedToggle" type="button" aria-expanded="false" aria-controls="memoryUnclassifiedList">
+                                <span>未归类记忆 <strong id="memoryUnclassifiedCount">0</strong> 条</span>
+                                <span class="material-symbols-outlined">expand_more</span>
+                            </button>
+                            <div class="memory-unclassified-list" id="memoryUnclassifiedList" hidden></div>
+                        </div>
+                        <div class="memory-ambiguity-section">
+                            <button class="memory-subsection-toggle" id="memoryAmbiguityToggle" type="button" aria-expanded="false" aria-controls="memoryAmbiguityList">
+                                <span>最近歧义 <strong id="memoryAmbiguityCount">0</strong> 条</span>
+                                <span class="material-symbols-outlined">expand_more</span>
+                            </button>
+                            <div class="memory-ambiguity-list" id="memoryAmbiguityList" hidden></div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/static/js/config.js
+++ b/static/js/config.js
@@ -219,7 +219,7 @@ export function loadConfig() {
 
             // 加载语音口令配置
             loadVoiceCommands();
-            loadVoiceMemoryData();
+            loadVoiceMemoryStats();
 
             // 加载 AI 配置
             if (data.data.ai_config) {
@@ -443,12 +443,21 @@ export function initMaxSongIndexUI() {
 
 // ========== 语音记忆 ==========
 
+let voiceMemoryEntities = [];
+let voiceMemoryAmbiguities = [];
+let voiceMemoryUnclassified = [];
+
 export function initVoiceMemoryUI() {
     const switchEl = document.getElementById('voiceMemorySwitch');
     const maxInput = document.getElementById('voiceMemoryMaxRecords');
     const refreshBtn = document.getElementById('refreshVoiceMemoryBtn');
     const clearBtn = document.getElementById('clearVoiceMemoryBtn');
     const listEl = document.getElementById('voiceMemoryList');
+    const managementToggle = document.getElementById('memoryManagementToggle');
+    const managementPanel = document.getElementById('memoryManagementPanel');
+    const ambiguityToggle = document.getElementById('memoryAmbiguityToggle');
+    const unclassifiedToggle = document.getElementById('memoryUnclassifiedToggle');
+    const unclassifiedList = document.getElementById('memoryUnclassifiedList');
 
     if (switchEl) {
         switchEl.addEventListener('change', function() {
@@ -472,13 +481,13 @@ export function initVoiceMemoryUI() {
 
     if (maxInput) {
         maxInput.addEventListener('change', function() {
-            const value = Math.max(10, Math.min(1000, parseInt(this.value) || 100));
+            const value = Math.max(10, Math.min(500, parseInt(this.value) || 100));
             this.value = value;
             apiPost('/config', { voice_memory_max_records: value })
                 .then(data => {
                     if (data.success) {
                         showSnackbar(data.warning || ('最大记忆数量已设为 ' + value), data.warning ? 'warning' : 'success');
-                        loadVoiceMemoryData();
+                        refreshVoiceMemoryView();
                     } else {
                         showSnackbar('保存失败：' + (data.error || '未知错误'), 'error');
                         loadConfig();
@@ -501,11 +510,77 @@ export function initVoiceMemoryUI() {
 
     if (listEl) {
         listEl.addEventListener('click', event => {
-            const button = event.target.closest('.memory-delete-btn');
+            const toggle = event.target.closest('.memory-entity-toggle');
+            if (toggle) {
+                toggleMemoryEntity(toggle);
+                return;
+            }
+            const deleteAlias = event.target.closest('.memory-alias-delete');
+            if (deleteAlias) {
+                deleteMemoryAlias(
+                    decodeURIComponent(deleteAlias.dataset.canonicalKey || ''),
+                    decodeURIComponent(deleteAlias.dataset.recordId || ''),
+                    decodeURIComponent(deleteAlias.dataset.query || ''),
+                );
+                return;
+            }
+            const addAlias = event.target.closest('.memory-alias-add');
+            if (addAlias) {
+                addMemoryAlias(decodeURIComponent(addAlias.dataset.canonicalKey || ''), addAlias.closest('.memory-entity-details'));
+                return;
+            }
+            const deleteEntity = event.target.closest('.memory-entity-delete');
+            if (deleteEntity) {
+                deleteMemoryEntity(
+                    decodeURIComponent(deleteEntity.dataset.canonicalKey || ''),
+                    decodeURIComponent(deleteEntity.dataset.song || ''),
+                );
+            }
+        });
+        listEl.addEventListener('keydown', event => {
+            if (event.key !== 'Enter' || !event.target.classList.contains('memory-alias-input')) return;
+            event.preventDefault();
+            const details = event.target.closest('.memory-entity-details');
+            const button = details?.querySelector('.memory-alias-add');
+            if (button) addMemoryAlias(decodeURIComponent(button.dataset.canonicalKey || ''), details);
+        });
+    }
+
+    if (managementToggle && managementPanel) {
+        managementToggle.addEventListener('click', () => {
+            const expanded = managementToggle.getAttribute('aria-expanded') === 'true';
+            managementToggle.setAttribute('aria-expanded', String(!expanded));
+            managementPanel.hidden = expanded;
+            if (!expanded) loadVoiceMemoryData();
+        });
+    }
+
+    if (ambiguityToggle) {
+        ambiguityToggle.addEventListener('click', () => {
+            const list = document.getElementById('memoryAmbiguityList');
+            if (!list) return;
+            const expanded = ambiguityToggle.getAttribute('aria-expanded') === 'true';
+            ambiguityToggle.setAttribute('aria-expanded', String(!expanded));
+            list.hidden = expanded;
+        });
+    }
+
+    if (unclassifiedToggle) {
+        unclassifiedToggle.addEventListener('click', () => {
+            if (!unclassifiedList) return;
+            const expanded = unclassifiedToggle.getAttribute('aria-expanded') === 'true';
+            unclassifiedToggle.setAttribute('aria-expanded', String(!expanded));
+            unclassifiedList.hidden = expanded;
+        });
+    }
+
+    if (unclassifiedList) {
+        unclassifiedList.addEventListener('click', event => {
+            const button = event.target.closest('.memory-unclassified-delete');
             if (!button) return;
-            deleteVoiceMemory(
-                decodeURIComponent(button.dataset.memoryId || ''),
-                decodeURIComponent(button.dataset.memoryQuery || ''),
+            deleteUnclassifiedMemory(
+                decodeURIComponent(button.dataset.recordId || ''),
+                decodeURIComponent(button.dataset.query || ''),
             );
         });
     }
@@ -518,64 +593,174 @@ function updateVoiceMemoryStatus(enabled) {
     }
 }
 
+function updateVoiceMemoryStats(stats = {}) {
+    const values = {
+        voiceMemoryCount: stats.recordCount || 0,
+        voiceMemoryEntityCount: stats.entityCount || 0,
+        voiceMemoryHitCount: stats.localHitCount || 0,
+        voiceMemoryUnclassifiedCount: stats.unclassifiedCount || 0,
+        memoryStatEntities: stats.entityCount || 0,
+        memoryStatQueries: stats.recordCount || 0,
+        memoryStatHits: stats.localHitCount || 0,
+        memoryStatSavedAi: stats.savedAiCalls || 0,
+        memoryAmbiguityCount: stats.ambiguousCount || 0,
+        memoryUnclassifiedCount: stats.unclassifiedCount || 0,
+    };
+    Object.entries(values).forEach(([id, value]) => {
+        const el = document.getElementById(id);
+        if (el) el.textContent = String(value);
+    });
+    const clearBtn = document.getElementById('clearVoiceMemoryBtn');
+    if (clearBtn) clearBtn.disabled = !values.voiceMemoryCount;
+    const unclassifiedSummary = document.getElementById('memoryUnclassifiedSummary');
+    if (unclassifiedSummary) unclassifiedSummary.hidden = !values.voiceMemoryUnclassifiedCount;
+}
+
+function loadVoiceMemoryStats() {
+    return apiGet('/memory/stats')
+        .then(data => {
+            if (!data.success || !data.data) throw new Error(data.error || '未知错误');
+            updateVoiceMemoryStats(data.data);
+        })
+        .catch(error => console.warn('[VoiceMemoryV3] stats failed', error));
+}
+
+function refreshVoiceMemoryView() {
+    const panel = document.getElementById('memoryManagementPanel');
+    return panel && !panel.hidden ? loadVoiceMemoryData() : loadVoiceMemoryStats();
+}
+
 export function loadVoiceMemoryData() {
     const listEl = document.getElementById('voiceMemoryList');
-    if (listEl) {
-        listEl.innerHTML = '<div class="empty-state memory-empty">加载中...</div>';
-    }
+    if (listEl) listEl.innerHTML = '<div class="empty-state memory-empty">加载中...</div>';
 
-    return apiGet('/memory')
-        .then(data => {
-            if (!data.success || !data.data) {
-                throw new Error(data.error || '未知错误');
-            }
-
-            const countEl = document.getElementById('voiceMemoryCount');
-            if (countEl) countEl.textContent = String(data.data.count || 0);
-
-            const clearBtn = document.getElementById('clearVoiceMemoryBtn');
-            if (clearBtn) clearBtn.disabled = !data.data.count;
-
-            const maxInput = document.getElementById('voiceMemoryMaxRecords');
-            if (maxInput) maxInput.value = data.data.max_records ?? 100;
-
-            renderVoiceMemoryList(data.data.records || []);
+    return Promise.all([apiGet('/memory/entities'), apiGet('/memory/ambiguous')])
+        .then(([entityData, ambiguityData]) => {
+            if (!entityData.success || !entityData.data) throw new Error(entityData.error || '未知错误');
+            if (!ambiguityData.success || !ambiguityData.data) throw new Error(ambiguityData.error || '未知错误');
+            voiceMemoryEntities = entityData.data.entities || [];
+            voiceMemoryUnclassified = entityData.data.unclassified || [];
+            voiceMemoryAmbiguities = ambiguityData.data.records || [];
+            updateVoiceMemoryStats({
+                ...(entityData.data.stats || {}),
+                ambiguousCount: voiceMemoryAmbiguities.length,
+            });
+            renderVoiceMemoryList(voiceMemoryEntities);
+            renderUnclassifiedMemory(voiceMemoryUnclassified);
+            renderMemoryAmbiguities(voiceMemoryAmbiguities);
         })
         .catch(error => {
-            if (listEl) {
-                listEl.innerHTML = '<div class="empty-state memory-empty">读取记忆失败</div>';
-            }
+            if (listEl) listEl.innerHTML = '<div class="empty-state memory-empty">读取记忆失败</div>';
             showSnackbar('读取语音记忆失败：' + error.message, 'error');
         });
 }
 
-function renderVoiceMemoryList(records) {
+function renderVoiceMemoryList(entities) {
     const listEl = document.getElementById('voiceMemoryList');
     if (!listEl) return;
-    if (!records.length) {
-        listEl.innerHTML = '<div class="empty-state memory-empty">暂无已保存的语音记忆</div>';
+    if (!entities.length) {
+        listEl.innerHTML = '<div class="empty-state memory-empty">暂无可聚合的歌曲记忆</div>';
         return;
     }
 
-    listEl.innerHTML = records.map(record => {
+    listEl.innerHTML = entities.map(entity => {
+        const canonicalKey = encodeURIComponent(entity.canonicalKey || '');
+        const songLabel = `${entity.songName || '未知歌曲'}${entity.artist ? ` · ${entity.artist}` : ''}`;
+        const aliases = (entity.aliases || []).map(alias => `<div class="memory-alias-row">
+            <div class="memory-alias-text">
+                <span>${escapeHtml(alias.query || alias.normalizedQuery || '')}</span>
+                ${alias.manualAlias ? '<span class="memory-alias-badge">手动</span>' : ''}
+            </div>
+            <button class="btn-icon danger memory-alias-delete" data-canonical-key="${canonicalKey}" data-record-id="${encodeURIComponent(alias.id)}" data-query="${encodeURIComponent(alias.query || alias.normalizedQuery || '')}" title="删除该用户说法" aria-label="删除该用户说法">
+                <span class="material-symbols-outlined">delete</span>
+            </button>
+        </div>`).join('');
+        return `<div class="memory-entity">
+            <button class="memory-entity-toggle" type="button" aria-expanded="false">
+                <div class="memory-entity-main">
+                    <div class="memory-entity-title">${escapeHtml(songLabel)}</div>
+                    <div class="memory-entity-meta">${Number(entity.queryCount) || 0} 种说法 · 命中 ${Number(entity.localHitCount) || 0} 次 · 最近使用：${escapeHtml(formatMemoryRelative(entity.lastUsedAt))}</div>
+                </div>
+                <span class="material-symbols-outlined">chevron_right</span>
+            </button>
+            <div class="memory-entity-details" hidden>
+                <div class="memory-alias-heading">用户说法</div>
+                <div class="memory-alias-list">${aliases || '<div class="memory-empty-inline">暂无用户说法</div>'}</div>
+                <div class="memory-alias-form">
+                    <input class="text-field memory-alias-input" type="text" minlength="2" maxlength="30" placeholder="添加 2–30 字别名" aria-label="添加用户说法">
+                    <button class="btn-icon memory-alias-add" type="button" data-canonical-key="${canonicalKey}" title="添加别名" aria-label="添加别名">
+                        <span class="material-symbols-outlined">add</span>
+                    </button>
+                </div>
+                <button class="btn-text memory-entity-delete" type="button" data-canonical-key="${canonicalKey}" data-song="${encodeURIComponent(songLabel)}">
+                    <span class="material-symbols-outlined">delete_sweep</span> 删除整组歌曲记忆
+                </button>
+            </div>
+        </div>`;
+    }).join('');
+}
+
+function toggleMemoryEntity(button) {
+    const details = button.closest('.memory-entity')?.querySelector('.memory-entity-details');
+    if (!details) return;
+    const expanded = button.getAttribute('aria-expanded') === 'true';
+    button.setAttribute('aria-expanded', String(!expanded));
+    details.hidden = expanded;
+}
+
+function renderMemoryAmbiguities(records) {
+    const list = document.getElementById('memoryAmbiguityList');
+    if (!list) return;
+    if (!records.length) {
+        list.innerHTML = '<div class="memory-empty-inline">暂无歧义记录</div>';
+        return;
+    }
+    list.innerHTML = records.map(record => {
+        const candidates = (record.candidates || [])
+            .map(candidate => `${candidate.songName || '未知歌曲'}${candidate.artist ? ` · ${candidate.artist}` : ''}`)
+            .join('、');
+        return `<div class="memory-ambiguity-item">
+            <div class="memory-query">${escapeHtml(record.query || record.normalizedQuery || '')}</div>
+            <div class="memory-song">${escapeHtml(candidates || `${Number(record.candidateCount) || 0} 个候选`)}</div>
+            <div class="memory-meta">出现 ${Number(record.occurrenceCount) || 1} 次 · ${escapeHtml(formatMemoryDate(record.lastSeenAt))}</div>
+        </div>`;
+    }).join('');
+}
+
+function renderUnclassifiedMemory(records) {
+    const list = document.getElementById('memoryUnclassifiedList');
+    if (!list) return;
+    if (!records.length) {
+        list.innerHTML = '<div class="memory-empty-inline">暂无未归类记忆</div>';
+        return;
+    }
+    list.innerHTML = records.map(record => {
         const query = record.query || record.normalizedQuery || '';
-        const song = record.songName || '未知歌曲';
-        const artist = record.artist || '未知歌手';
-        return `<div class="memory-item">
+        const metadata = record.songName
+            ? `${record.songName}${record.artist ? ` · ${record.artist}` : ''}`
+            : '旧版记录，缺少歌曲元数据';
+        return `<div class="memory-unclassified-item">
             <div class="memory-item-main">
                 <div class="memory-query" title="${escapeHtml(query)}">${escapeHtml(query)}</div>
-                <div class="memory-song">${escapeHtml(song)} · ${escapeHtml(artist)}</div>
-                <div class="memory-meta">
-                    <span>命中 ${Number(record.hitCount) || 0}</span>
-                    <span>成功 ${Number(record.successCount) || 0}</span>
-                    <span>更新 ${escapeHtml(formatMemoryDate(record.updatedAt))}</span>
-                </div>
+                <div class="memory-song">${escapeHtml(metadata)}</div>
+                <div class="memory-meta"><span>命中 ${Number(record.hitCount) || 0}</span><span>成功 ${Number(record.successCount) || 0}</span><span>更新 ${escapeHtml(formatMemoryDate(record.updatedAt))}</span></div>
             </div>
-            <button class="btn-icon danger memory-delete-btn" data-memory-id="${encodeURIComponent(record.id)}" data-memory-query="${encodeURIComponent(query)}" title="删除该条记忆" aria-label="删除该条记忆">
+            <button class="btn-icon danger memory-unclassified-delete" data-record-id="${encodeURIComponent(record.id)}" data-query="${encodeURIComponent(query)}" title="删除该条未归类记忆" aria-label="删除该条未归类记忆">
                 <span class="material-symbols-outlined">delete</span>
             </button>
         </div>`;
     }).join('');
+}
+
+function formatMemoryRelative(value) {
+    const date = new Date(value);
+    if (!value || Number.isNaN(date.getTime())) return '未知';
+    const seconds = Math.max(0, Math.floor((Date.now() - date.getTime()) / 1000));
+    if (seconds < 60) return '刚刚';
+    if (seconds < 3600) return `${Math.floor(seconds / 60)} 分钟前`;
+    if (seconds < 86400) return `${Math.floor(seconds / 3600)} 小时前`;
+    if (seconds < 604800) return `${Math.floor(seconds / 86400)} 天前`;
+    return formatMemoryDate(value);
 }
 
 function formatMemoryDate(value) {
@@ -584,18 +769,53 @@ function formatMemoryDate(value) {
     return date.toLocaleString('zh-CN', { hour12: false });
 }
 
-function deleteVoiceMemory(id, query) {
-    if (!id) return;
-    if (!confirm(`确定删除语音记忆“${query || id}”吗？`)) return;
-
-    apiDelete('/memory?id=' + encodeURIComponent(id))
+function addMemoryAlias(canonicalKey, details) {
+    const input = details?.querySelector('.memory-alias-input');
+    const alias = input?.value.trim() || '';
+    const length = Array.from(alias).length;
+    if (length < 2 || length > 30) {
+        showSnackbar('别名长度必须为 2 到 30 个字符', 'error');
+        return;
+    }
+    apiPost('/memory/aliases', { canonicalKey, alias })
         .then(data => {
-            if (data.success) {
-                showSnackbar('记忆已删除', 'success');
-                loadVoiceMemoryData();
-            } else {
-                showSnackbar('删除失败：' + (data.error || '未知错误'), 'error');
-            }
+            if (!data.success) throw new Error(data.error || '未知错误');
+            showSnackbar('别名已添加', 'success');
+            loadVoiceMemoryData();
+        })
+        .catch(error => showSnackbar('添加失败：' + error.message, 'error'));
+}
+
+function deleteMemoryAlias(canonicalKey, recordId, query) {
+    if (!confirm(`确定删除用户说法“${query}”吗？`)) return;
+    apiDelete('/memory/aliases?canonicalKey=' + encodeURIComponent(canonicalKey) + '&recordId=' + encodeURIComponent(recordId))
+        .then(data => {
+            if (!data.success) throw new Error(data.error || '未知错误');
+            showSnackbar('用户说法已删除', 'success');
+            loadVoiceMemoryData();
+        })
+        .catch(error => showSnackbar('删除失败：' + error.message, 'error'));
+}
+
+function deleteMemoryEntity(canonicalKey, song) {
+    if (!confirm(`确定删除“${song}”的全部语音记忆吗？此操作无法撤销。`)) return;
+    apiDelete('/memory/entity?canonicalKey=' + encodeURIComponent(canonicalKey))
+        .then(data => {
+            if (!data.success) throw new Error(data.error || '未知错误');
+            showSnackbar('整组歌曲记忆已删除', 'success');
+            loadVoiceMemoryData();
+        })
+        .catch(error => showSnackbar('删除失败：' + error.message, 'error'));
+}
+
+function deleteUnclassifiedMemory(recordId, query) {
+    if (!recordId) return;
+    if (!confirm(`确定删除未归类记忆“${query || recordId}”吗？`)) return;
+    apiDelete('/memory?id=' + encodeURIComponent(recordId))
+        .then(data => {
+            if (!data.success) throw new Error(data.error || '未知错误');
+            showSnackbar('未归类记忆已删除', 'success');
+            loadVoiceMemoryData();
         })
         .catch(error => showSnackbar('删除失败：' + error.message, 'error'));
 }
@@ -611,7 +831,7 @@ function clearAllVoiceMemory() {
     apiDelete('/memory/all')
         .then(data => {
             if (data.success) {
-                showSnackbar('全部语音记忆已清空', 'success');
+                showSnackbar(data.warning || '全部语音记忆已清空', data.warning ? 'warning' : 'success');
                 loadVoiceMemoryData();
             } else {
                 showSnackbar('清空失败：' + (data.error || '未知错误'), 'error');


### PR DESCRIPTION
本 PR 基于 Voice Memory V2 增强语音记忆管理能力，新增 Voice Memory V3 可视化管理功能。

本次改动目标是在保持插件轻量化、兼容性和稳定性的前提下，让用户能够了解系统已经学习的语音记忆，并可以对记忆内容进行查看、管理和优化。

主要功能：

- 新增基于歌曲实体的记忆聚合能力
- 新增 Voice Memory V3 管理界面
- 支持查看已学习歌曲、用户说法、记忆命中次数以及节省 AI 调用统计
- 支持用户手动添加歌曲别名
- 支持查看、删除单条用户说法
- 支持删除整组歌曲记忆
- 新增歧义记录管理能力，方便后续优化匹配准确性
- 新增未归类旧记忆展示和管理能力

兼容性设计：

- Voice Memory 可以独立开启，不依赖 AI 口令分析
- 已存在的语音记忆命中时无需调用 AI
- AI 分析主要用于学习新的复杂语音口令
- 保留 V1 exact 精确匹配逻辑
- 保留 V2 entity 实体解析逻辑
- 固定控制命令仍保持最高优先级
- 未修改歌单逻辑和外部搜索逻辑
- 保持旧版本记忆数据兼容，旧数据不会影响正常播放流程

性能与稳定性：

- 实体聚合仅在管理接口请求时计算，不进入实时语音处理主路径
- 记忆管理异常不会阻断播放流程
- 统计失败不会影响语音解析和播放
- 默认最大记忆数量 100 条，支持配置范围 10-500 条
- 保持运行资源占用较低，不影响 MIoT 插件原有功能

测试：

已完成以下验证：

- npm run build ✅
- npm run validate ✅
- 小米智能音箱 + Songloft MIoT 插件真实环境测试 ✅
- 首次播放歌曲 → AI 分析 → 播放成功 → 自动记录记忆 ✅
- 重复播放歌曲 → Voice Memory 命中 → 跳过 AI 直接播放 ✅
- AI 分析关闭情况下，已有记忆仍可正常命中播放 ✅
- 实体聚合、别名添加、别名删除功能验证 ✅
- 固定控制命令优先级验证 ✅
- 未知口令安全 fallback 验证 ✅

该版本将 Voice Memory 从单纯的语音缓存机制升级为用户可理解、可管理的个人语音记忆系统，为后续更智能的音乐解析和跨平台语音记忆能力扩展提供基础。