### PR TITLE
feat(ui): 将账号管理移动到设备与连接设置页

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -22,5 +22,5 @@
   "updateUrl": "https://raw.githubusercontent.com/songloft-org/songloft-plugin-miot/main/plugin.json",
   "download_url": "https://github.com/songloft-org/songloft-plugin-miot/releases/download/v2026.7.15/miot.jsplugin.zip",
   "entryHash": "e64dda62664930ce266427951261c570802e705ed8cc55748f04bd3e77182856",
-  "zipHash": "fbab524ea304c339c2338dfcc263178fdd36f77e2d6c3b6501cd83c5509c922f"
+  "zipHash": "b10ed596c2efdb181b243aa4a2de355411c1c997500f9ccf7bfa0431a00ab5ad"
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -129,7 +129,6 @@ html[data-theme="dark"] {
     padding-top: 112px;
 }
 
-#tab-devices,
 #tab-settings {
     padding-bottom: calc(24px + env(safe-area-inset-bottom));
 }
@@ -2029,10 +2028,6 @@ html[data-theme="dark"] {
         bottom: 120px;
     }
 
-    #tab-devices .container {
-        max-width: 900px;
-    }
-
     .dialog {
         min-width: 560px;
     }
@@ -2043,17 +2038,6 @@ html[data-theme="dark"] {
 
     .container {
         max-width: 900px;
-    }
-
-    #tab-devices .container {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 24px;
-        max-width: 1100px;
-    }
-
-    #tab-devices .container > .card {
-        margin-bottom: 0;
     }
 
     .player-bar-top {
@@ -2074,10 +2058,6 @@ html[data-theme="dark"] {
 
     .container {
         max-width: 1000px;
-    }
-
-    #tab-devices .container {
-        max-width: 1200px;
     }
 
     .player-bar-top {
@@ -3820,6 +3800,10 @@ html.embed .player-bar-cover {
     border: 1px solid var(--md-outline-variant);
     border-radius: var(--md-radius-lg);
     box-shadow: none;
+}
+
+#accountManagementSection {
+    scroll-margin-top: 72px;
 }
 
 /* 宽屏（>=600px）：双栏 Master/Detail，对齐主程序 useWideLayout */

--- a/static/index.html
+++ b/static/index.html
@@ -16,9 +16,6 @@
         </button>
         <span class="material-symbols-outlined app-bar-icon" id="appBarIcon">speaker</span>
         <h1 id="appBarTitle">MIoT 智能音箱</h1>
-        <button class="btn-icon" id="accountBtn" title="账号管理">
-            <span class="material-symbols-outlined">person</span>
-        </button>
         <button class="btn-icon" id="settingsBtn" title="设置">
             <span class="material-symbols-outlined">settings</span>
         </button>
@@ -60,9 +57,44 @@
         </div>
     </div>
 
-    <!-- Page: 账号管理 -->
-    <div class="page-content" id="tab-devices">
+    <!-- Page: 设置 -->
+    <div class="page-content" id="tab-settings">
+        <div class="settings-layout" id="settingsLayout">
+            <nav class="settings-nav" id="settingsNav" aria-label="设置分类"></nav>
+            <div class="settings-content" id="settingsContent">
         <div class="container">
+            <!-- 服务器地址配置卡片 -->
+            <div class="card" data-category="device">
+                <div class="card-header">
+                    <span class="material-symbols-outlined">dns</span>
+                    服务器配置
+                </div>
+                <div class="card-body">
+                    <div class="form-group">
+                        <label class="form-label">服务器地址</label>
+                        <select class="text-field" id="serverHostSelect" aria-label="选择服务器地址">
+                            <option value="" disabled selected>请选择服务器地址...</option>
+                        </select>
+                        <input type="text" class="text-field" id="serverHostCustom" placeholder="例如: http://192.168.1.100:58091" aria-label="自定义服务器地址" style="display:none;margin-top:8px">
+                    </div>
+                    <div class="server-host-warning" id="serverHostWarning" style="display:none">
+                        <span class="material-symbols-outlined" style="font-size:16px;flex-shrink:0">warning</span>
+                        <span id="serverHostWarningText"></span>
+                    </div>
+                    <div class="toolbar" style="padding:12px 0 0;justify-content:flex-end">
+                        <button class="btn-text" id="autoFillBtn">
+                            <span class="material-symbols-outlined">auto_fix_high</span>
+                            自动填充
+                        </button>
+                        <button class="btn-filled" id="saveConfigBtn">
+                            <span class="material-symbols-outlined">save</span>
+                            保存
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 账号管理区域 -->
             <!-- 隐藏的 select 元素供 JS 使用 -->
             <div style="display:none">
                 <select id="accountSelect" aria-label="选择账号"></select>
@@ -73,7 +105,7 @@
             </div>
 
             <!-- 账号登录卡片 -->
-            <div class="card">
+            <div class="card" id="accountManagementSection" data-category="device">
                 <div class="card-header">
                     <span class="material-symbols-outlined">person_add</span>
                     添加账号
@@ -174,52 +206,13 @@
             </div>
 
             <!-- 已登录账号列表卡片 -->
-            <div class="card">
+            <div class="card" data-category="device">
                 <div class="card-header">
                     <span class="material-symbols-outlined">group</span>
                     已登录账号
                 </div>
                 <div class="card-body" id="accountList">
                     <div class="empty-state">暂无账号，请先添加</div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <!-- Page: 设置 -->
-    <div class="page-content" id="tab-settings">
-        <div class="settings-layout" id="settingsLayout">
-            <nav class="settings-nav" id="settingsNav" aria-label="设置分类"></nav>
-            <div class="settings-content" id="settingsContent">
-        <div class="container">
-            <!-- 服务器地址配置卡片 -->
-            <div class="card" data-category="device">
-                <div class="card-header">
-                    <span class="material-symbols-outlined">dns</span>
-                    服务器配置
-                </div>
-                <div class="card-body">
-                    <div class="form-group">
-                        <label class="form-label">服务器地址</label>
-                        <select class="text-field" id="serverHostSelect" aria-label="选择服务器地址">
-                            <option value="" disabled selected>请选择服务器地址...</option>
-                        </select>
-                        <input type="text" class="text-field" id="serverHostCustom" placeholder="例如: http://192.168.1.100:58091" aria-label="自定义服务器地址" style="display:none;margin-top:8px">
-                    </div>
-                    <div class="server-host-warning" id="serverHostWarning" style="display:none">
-                        <span class="material-symbols-outlined" style="font-size:16px;flex-shrink:0">warning</span>
-                        <span id="serverHostWarningText"></span>
-                    </div>
-                    <div class="toolbar" style="padding:12px 0 0;justify-content:flex-end">
-                        <button class="btn-text" id="autoFillBtn">
-                            <span class="material-symbols-outlined">auto_fix_high</span>
-                            自动填充
-                        </button>
-                        <button class="btn-filled" id="saveConfigBtn">
-                            <span class="material-symbols-outlined">save</span>
-                            保存
-                        </button>
-                    </div>
                 </div>
             </div>
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -58,12 +58,19 @@ let currentPage = 'player';
 
 /**
  * 导航到子页面
- * @param {string} pageId - 'devices' 或 'settings'
+ * @param {string} pageId - 'settings'，兼容旧的 'devices' 账号管理入口
  */
 window.navigateTo = function(pageId) {
-    if (currentPage === pageId) return;
-    history.pushState({ page: pageId }, '', '#' + pageId);
-    showPage(pageId);
+    const openAccountManagement = pageId === 'devices';
+    const targetPage = openAccountManagement ? 'settings' : pageId;
+
+    if (currentPage === targetPage) {
+        if (openAccountManagement) openAccountManagementSettings();
+        return;
+    }
+
+    history.pushState({ page: targetPage, accountManagement: openAccountManagement }, '', '#' + targetPage);
+    showPage(targetPage, { openAccountManagement });
 };
 
 /**
@@ -75,9 +82,13 @@ window.navigateBack = function() {
 
 /**
  * 显示指定页面，更新 AppBar 状态
- * @param {string} pageId - 'player', 'devices', 'settings'
+ * @param {string} pageId - 'player' 或 'settings'，兼容旧的 'devices'
+ * @param {{ openAccountManagement?: boolean }} [options]
  */
-function showPage(pageId) {
+function showPage(pageId, options = {}) {
+    const openAccountManagement = options.openAccountManagement || pageId === 'devices';
+    if (pageId === 'devices') pageId = 'settings';
+
     currentPage = pageId;
 
     document.querySelectorAll('.page-content').forEach(el => el.classList.remove('active'));
@@ -92,13 +103,11 @@ function showPage(pageId) {
     const navBackBtn = document.getElementById('navBackBtn');
     const appBarIcon = document.getElementById('appBarIcon');
     const appBarTitle = document.getElementById('appBarTitle');
-    const accountBtn = document.getElementById('accountBtn');
     const settingsBtn = document.getElementById('settingsBtn');
 
     if (navBackBtn) navBackBtn.style.display = isMain ? 'none' : '';
     if (appBarIcon) appBarIcon.style.display = isMain ? '' : 'none';
-    if (appBarTitle) appBarTitle.textContent = isMain ? 'MIoT 智能音箱' : pageId === 'devices' ? '账号管理' : '设置';
-    if (accountBtn) accountBtn.style.display = isMain ? '' : 'none';
+    if (appBarTitle) appBarTitle.textContent = isMain ? 'MIoT 智能音箱' : '设置';
     if (settingsBtn) settingsBtn.style.display = isMain ? '' : 'none';
 
     // 工具栏 + 播放栏仅播放页可见
@@ -109,25 +118,23 @@ function showPage(pageId) {
     if (playerBar) playerBar.style.display = isMain ? '' : 'none';
 
     // 子页面数据加载
-    if (pageId === 'devices') {
-        loadDevices();
-        loadAccounts();
-    }
     if (pageId === 'settings') {
         loadConfig();
         loadSchedules();
         loadIndexStatus();
+        loadAccounts();
         initSettingsMasterDetail();
         const layout = document.getElementById('settingsLayout');
         if (layout) layout.classList.remove('view-detail');
         // 列表态（含宽屏双栏）：顶部返回按钮保留，用于退出设置页回到播放页
         settingsInDetail = false;
+        if (openAccountManagement) openAccountManagementSettings();
     }
 }
 
 // ========== 设置页 Master/Detail（对齐主程序设置页响应式范式） ==========
 const SETTINGS_CATEGORIES = [
-    { id: 'device',   icon: 'router',            title: '设备与连接',   subtitle: '服务器、自定义型号、指示灯' },
+    { id: 'device',   icon: 'router',            title: '设备与连接',   subtitle: '服务器、账号、指示灯、自定义型号' },
     { id: 'playback', icon: 'lyrics',            title: '播放与显示',   subtitle: '音频格式、触屏歌词、默认封面' },
     { id: 'voice',    icon: 'record_voice_over', title: '语音交互',     subtitle: '对话监听、口令、记忆、外部搜索' },
     { id: 'schedule', icon: 'schedule',          title: '定时与自动化', subtitle: '时区、定时任务' },
@@ -186,6 +193,28 @@ function selectSettingsCategory(id) {
 function initSettingsMasterDetail() {
     if (!settingsNavBuilt) buildSettingsNav();
     selectSettingsCategory(settingsSelectedCategory);
+}
+
+// 兼容旧账号管理入口：进入设置的设备分类并定位到账号管理区域
+function openAccountManagementSettings() {
+    selectSettingsCategory('device');
+
+    const layout = document.getElementById('settingsLayout');
+    if (layout && window.matchMedia('(max-width: 599px)').matches) {
+        layout.classList.add('view-detail');
+        settingsInDetail = true;
+
+        const navBackBtn = document.getElementById('navBackBtn');
+        if (navBackBtn) navBackBtn.style.display = '';
+
+        const appBarTitle = document.getElementById('appBarTitle');
+        if (appBarTitle) appBarTitle.textContent = '设备与连接';
+    }
+
+    requestAnimationFrame(() => {
+        const section = document.getElementById('accountManagementSection');
+        if (section) section.scrollIntoView({ block: 'start' });
+    });
 }
 
 // 回到分类列表（手机端详情态的返回目标）
@@ -304,7 +333,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // 监听浏览器返回/前进
     window.addEventListener('popstate', (event) => {
         const page = event.state?.page || event.state?.tab || 'player';
-        showPage(page);
+        showPage(page, {
+            openAccountManagement: page === 'devices' || event.state?.accountManagement === true,
+        });
     });
 
     // 初始化 Tracely 监控 SDK
@@ -345,11 +376,6 @@ document.addEventListener('DOMContentLoaded', () => {
             exitSettingsDetail();
         }
     });
-
-    const accountBtn = document.getElementById('accountBtn');
-    if (accountBtn) {
-        accountBtn.addEventListener('click', () => navigateTo('devices'));
-    }
 
     const settingsNavBtn = document.getElementById('settingsBtn');
     if (settingsNavBtn) {


### PR DESCRIPTION
## 变更说明

本 PR 将 MIoT 插件原本位于独立账号管理页面的相关功能，移动到设置页的「设备与连接」分类中，使账号登录、已登录账号和设备列表管理入口更加集中。

调整后的「设备与连接」页面顺序为：

1. 服务器配置
2. 账号管理
   - 添加账号
   - 已登录账号
   - 设备列表
   - 重新登录
   - 删除账号
   - 设备勾选 / 设备管理
3. 指示灯
4. 自定义 Music API 型号

同时移除了播放页左上角原有的人物 / 账号图标按钮，将设置齿轮按钮移动到该位置；右上角刷新按钮及其逻辑保持不变。

## 变更范围

本 PR 仅调整前端 UI 位置和旧账号入口的导航兼容逻辑。

未修改以下内容：

- Voice Memory V1 / V2 / V3
- 播放逻辑
- 登录 API
- 设备绑定逻辑
- 设备选择业务逻辑
- 歌单逻辑
- 外部搜索逻辑
- 后端 `src/` 目录代码

## 实现细节

- 将原 `#tab-devices` 中的账号管理 DOM 整体迁移到设置页「设备与连接」分类。
- 保留原有账号登录、账号列表、设备列表相关 DOM id 和事件绑定依赖。
- 移除播放页顶部的账号按钮。
- 保留设置按钮，并将其放到原账号按钮位置。
- 兼容旧的 `navigateTo('devices')` 调用，使其跳转到设置页并选中「设备与连接」分类。
- 更新 `plugin.json` 中的 `zipHash`，使其与当前构建产物一致。

## 验证结果

已完成以下验证：

- `npm run build`
- `npm run validate`

结果：

- 构建成功
- 插件校验通过
- 手动 UI 测试通过

手动测试内容包括：

- 播放页左上角仅显示设置齿轮按钮
- 播放页右上角刷新按钮保持不变
- 点击设置按钮可进入设置页
- 账号管理显示在「设备与连接」中，位于「服务器配置」下方、「指示灯」上方
- 扫码登录、账号密码登录、手动 Token 登录入口正常显示
- 已登录账号、设备列表、设备勾选功能正常显示